### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/patricktcoakley/gdvm/security/code-scanning/3](https://github.com/patricktcoakley/gdvm/security/code-scanning/3)

To fix the problem, an explicit `permissions` block should be added to the `test` job in `.github/workflows/release.yml`. This block should grant only the minimum necessary permissions for the job to perform its tasks. Since the `test` job only checks out code and runs build/test commands, it does not require any write permissions, nor elevated access to other APIs. Therefore, add `permissions: contents: read` to the `test` job block (just below `runs-on: ubuntu-latest`). No new imports, methods, or code definitions are needed; this is a straightforward modification to the workflow YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
