### PR TITLE
Search cache

### DIFF
--- a/Fgvm.Cli/Command/InstallCommand.cs
+++ b/Fgvm.Cli/Command/InstallCommand.cs
@@ -5,7 +5,6 @@ using Fgvm.Types;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 using System.Security;
-using System.Security.Cryptography;
 using ZLogger;
 using Messages = Fgvm.Cli.Error.Messages;
 
@@ -30,7 +29,6 @@ public sealed class InstallCommand(
     /// <param name="cancellationToken">Cancellation token</param>
     /// <param name="query">Version query arguments</param>
     /// <exception cref="ArgumentException"></exception>
-    /// <exception cref="CryptographicException"></exception>
     /// <exception cref="SecurityException"></exception>
     [Command("install|i")]
     public async Task Install(bool @default = false, CancellationToken cancellationToken = default, [Argument] params string[] query) =>
@@ -43,7 +41,6 @@ public sealed class InstallCommand(
     /// <param name="setAsDefault">Whether to set the installed version as default</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <exception cref="ArgumentException"></exception>
-    /// <exception cref="CryptographicException"></exception>
     /// <exception cref="SecurityException"></exception>
     private async Task InstallCore(string[] query, bool setAsDefault, CancellationToken cancellationToken)
     {
@@ -61,9 +58,6 @@ public sealed class InstallCommand(
 
                 case Result<InstallationOutcome, InstallationError>.Failure(InstallationError.ChecksumMismatch mismatch):
                     throw new SecurityException(Messages.ChecksumMismatch(mismatch.FileName, mismatch.Expected, mismatch.Actual));
-
-                case Result<InstallationOutcome, InstallationError>.Failure(InstallationError.ChecksumParseError parseError):
-                    throw new CryptographicException(Messages.ChecksumParseError(parseError.Content));
 
                 case Result<InstallationOutcome, InstallationError>.Failure(InstallationError.Failed failed):
                     throw new InvalidOperationException(Messages.InstallationFailed(failed.Reason));

--- a/Fgvm.Cli/Command/SearchCommand.cs
+++ b/Fgvm.Cli/Command/SearchCommand.cs
@@ -21,13 +21,15 @@ public sealed class SearchCommand(
     ///     Search available Godot versions.
     /// </summary>
     /// <param name="json">-j, Output results as JSON.</param>
+    /// <param name="noCache">-F, Force a remote refresh instead of reading releases.json.</param>
     /// <param name="query">Optional query arguments.</param>
     /// <param name="cancellationToken"></param>
     [Command("search|s")]
-    public async Task Search(bool json = false, [Argument] string[]? query = null, CancellationToken cancellationToken = default)
+    public async Task Search(bool json = false, bool noCache = false, [Argument] string[]? query = null, CancellationToken cancellationToken = default)
     {
         var searchQuery = query ?? [];
-        var result = await releaseManager.SearchRemoteReleases(searchQuery, cancellationToken);
+        var fetchMode = noCache ? ReleaseFetchMode.ForceRemote : ReleaseFetchMode.UseCache;
+        var result = await releaseManager.SearchRemoteReleases(searchQuery, fetchMode, cancellationToken);
 
         switch (result)
         {

--- a/Fgvm.Cli/Error/Messages.cs
+++ b/Fgvm.Cli/Error/Messages.cs
@@ -160,14 +160,11 @@ public static class Messages
     public static string UnableToGetRelease(string version) => $"Unable to get release with selection `{version}`.";
 
     // Checksum verification
-    public static string ChecksumVerificationFailed(string releaseNameWithRuntime, NetworkError error) =>
-        $"[orange1]Warning: Could not verify checksum for {releaseNameWithRuntime}. Installation continued without verification.[/]";
+    public static string ChecksumUnavailable(string releaseNameWithRuntime) =>
+        $"[orange1]Warning: Checksum unavailable for {releaseNameWithRuntime}. Installation continued without verification.[/]";
 
     public static string ChecksumMismatch(string fileName, string expected, string actual) =>
         $"[red]Checksum mismatch for {fileName}![/]\n[red]Expected: {expected}[/]\n[red]Actual:   {actual}[/]\n[red]This could indicate a corrupted download or security issue.[/]";
-
-    public static string ChecksumParseError(string content) =>
-        $"[red]Failed to parse checksum file.[/]\n[dim]Content preview: {(content.Length > 100 ? content[..100] + "..." : content)}[/]";
 
     private static string BuildInstallQuery(string projectVersion, bool isDotNet)
     {

--- a/Fgvm.Cli/Fgvm.Cli.csproj
+++ b/Fgvm.Cli/Fgvm.Cli.csproj
@@ -36,19 +36,19 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.2" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
-        <PackageReference Include="Spectre.Console" Version="0.54.0" />
-        <PackageReference Include="ZLogger" Version="2.5.10" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.7"/>
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7"/>
+        <PackageReference Include="Spectre.Console" Version="0.55.2"/>
+        <PackageReference Include="ZLogger" Version="2.5.10"/>
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="Fgvm.Tests" />
+        <InternalsVisibleTo Include="Fgvm.Tests"/>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Fgvm\Fgvm.csproj" />
+        <ProjectReference Include="..\Fgvm\Fgvm.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/Fgvm.Cli/Program.cs
+++ b/Fgvm.Cli/Program.cs
@@ -75,6 +75,7 @@ public class Program
 
         // Register core services
         services.AddSingleton<IDownloadClient, DownloadClient>();
+        services.AddSingleton<IReleaseCatalog, ReleaseCatalog>();
         services.AddSingleton<IReleaseManager, ReleaseManager>();
         services.AddSingleton<IInstallationService, InstallationService>();
         services.AddSingleton<IProjectManager, ProjectManager>();

--- a/Fgvm.Cli/Services/InstallationOrchestrator.cs
+++ b/Fgvm.Cli/Services/InstallationOrchestrator.cs
@@ -96,9 +96,9 @@ public sealed class InstallationOrchestrator(
                 var successMessage = GetInstallationSuccessMessage(release, setAsDefault, wasAutoSetAsDefault);
                 console.MarkupLine(successMessage);
 
-                if (checksumStatus is ChecksumVerification.Failed(var networkError))
+                if (checksumStatus is ChecksumVerification.Unavailable)
                 {
-                    console.MarkupLine(Messages.ChecksumVerificationFailed(release, networkError));
+                    console.MarkupLine(Messages.ChecksumUnavailable(release));
                 }
 
                 if (symlinkWarning is not null)

--- a/Fgvm.Tests.EndToEnd/EndToEndTests.cs
+++ b/Fgvm.Tests.EndToEnd/EndToEndTests.cs
@@ -139,7 +139,9 @@ public class EndToEndTests(TestContainerFixture fixture) : IClassFixture<TestCon
             var content = await fixture.ReadFile(releasesPath);
             using var document = JsonDocument.Parse(content);
             Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
-            Assert.Contains(document.RootElement.EnumerateObject(), property => property.Value.TryGetProperty("stable", out _));
+            Assert.True(document.RootElement.TryGetProperty("lastUpdated", out _));
+            Assert.True(document.RootElement.TryGetProperty("releases", out var releases));
+            Assert.Contains(releases.EnumerateObject(), property => property.Value.TryGetProperty("stable", out _));
         }
         finally
         {
@@ -166,7 +168,37 @@ public class EndToEndTests(TestContainerFixture fixture) : IClassFixture<TestCon
             var content = await fixture.ReadFile(releasesPath);
             using var document = JsonDocument.Parse(content);
             Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
-            Assert.Contains(document.RootElement.EnumerateObject(), property => property.Value.TryGetProperty("stable", out _));
+            Assert.True(document.RootElement.TryGetProperty("lastUpdated", out _));
+            Assert.True(document.RootElement.TryGetProperty("releases", out var releases));
+            Assert.Contains(releases.EnumerateObject(), property => property.Value.TryGetProperty("stable", out _));
+        }
+        finally
+        {
+            await fixture.ExecuteShellCommand("rm", ["-rf", home]);
+        }
+    }
+
+    [Fact]
+    public async Task SearchCommandRebuildsInvalidReleasesJson()
+    {
+        var home = $"/tmp/fgvm-cache-invalid-{Guid.NewGuid():N}";
+        var root = $"{home}/fgvm";
+        var releasesPath = $"{root}/releases.json";
+
+        try
+        {
+            await fixture.ExecuteShellCommand("rm", ["-rf", home]);
+            await fixture.ExecuteShellCommand("mkdir", ["-p", root]);
+            await fixture.ExecuteShellCommand("sh", ["-c", $"printf '{{ nope' > {releasesPath}"]);
+
+            var result = await fixture.ExecuteShellCommand("sh", ["-c", $"FGVM_HOME={home} {fixture.FgvmPath} search --json 4.5"]);
+
+            await fixture.AssertSuccessfulExecutionAsync(result, "search with invalid releases.json");
+            var content = await fixture.ReadFile(releasesPath);
+            using var document = JsonDocument.Parse(content);
+            Assert.True(document.RootElement.TryGetProperty("lastUpdated", out _));
+            Assert.True(document.RootElement.TryGetProperty("releases", out var releases));
+            Assert.Contains(releases.EnumerateObject(), property => property.Value.TryGetProperty("stable", out _));
         }
         finally
         {
@@ -187,7 +219,7 @@ public class EndToEndTests(TestContainerFixture fixture) : IClassFixture<TestCon
             await fixture.ExecuteShellCommand("mkdir", ["-p", root]);
             await fixture.ExecuteShellCommand("sh", [
                 "-c",
-                $"cat > {releasesPath} << 'EOF'\n{{\"4.999\":{{\"stable\":{{}}}}}}\nEOF"
+                $"cat > {releasesPath} << 'EOF'\n{{\"lastUpdated\":\"2999-01-01T00:00:00+00:00\",\"releases\":{{\"4.999\":{{\"stable\":{{}}}}}}}}\nEOF"
             ]);
 
             var cachedSearch = await fixture.ExecuteShellCommand("sh", ["-c", $"FGVM_HOME={home} {fixture.FgvmPath} search --json 4.999"]);
@@ -203,7 +235,9 @@ public class EndToEndTests(TestContainerFixture fixture) : IClassFixture<TestCon
 
             using var document = JsonDocument.Parse(content);
             Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
-            Assert.Contains(document.RootElement.EnumerateObject(), property => property.Value.TryGetProperty("stable", out _));
+            Assert.True(document.RootElement.TryGetProperty("lastUpdated", out _));
+            Assert.True(document.RootElement.TryGetProperty("releases", out var releases));
+            Assert.Contains(releases.EnumerateObject(), property => property.Value.TryGetProperty("stable", out _));
         }
         finally
         {

--- a/Fgvm.Tests.EndToEnd/EndToEndTests.cs
+++ b/Fgvm.Tests.EndToEnd/EndToEndTests.cs
@@ -121,6 +121,97 @@ public class EndToEndTests(TestContainerFixture fixture) : IClassFixture<TestCon
     }
 
     [Fact]
+    public async Task SearchCommandCreatesReleasesJsonWhenMissing()
+    {
+        var home = $"/tmp/fgvm-cache-missing-{Guid.NewGuid():N}";
+        var root = $"{home}/fgvm";
+        var releasesPath = $"{root}/releases.json";
+
+        try
+        {
+            await fixture.ExecuteShellCommand("rm", ["-rf", home]);
+
+            var result = await fixture.ExecuteShellCommand("sh", ["-c", $"FGVM_HOME={home} {fixture.FgvmPath} search --json 4.5"]);
+
+            await fixture.AssertSuccessfulExecutionAsync(result, "search");
+            Assert.True(await fixture.FileExists(releasesPath), "Expected search to create releases.json when no cache exists.");
+
+            var content = await fixture.ReadFile(releasesPath);
+            using var document = JsonDocument.Parse(content);
+            Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
+            Assert.Contains(document.RootElement.EnumerateObject(), property => property.Value.TryGetProperty("stable", out _));
+        }
+        finally
+        {
+            await fixture.ExecuteShellCommand("rm", ["-rf", home]);
+        }
+    }
+
+    [Fact]
+    public async Task SearchCommandNoCacheCreatesReleasesJsonWhenMissing()
+    {
+        var home = $"/tmp/fgvm-no-cache-missing-{Guid.NewGuid():N}";
+        var root = $"{home}/fgvm";
+        var releasesPath = $"{root}/releases.json";
+
+        try
+        {
+            await fixture.ExecuteShellCommand("rm", ["-rf", home]);
+
+            var result = await fixture.ExecuteShellCommand("sh", ["-c", $"FGVM_HOME={home} {fixture.FgvmPath} search --no-cache --json 4.5"]);
+
+            await fixture.AssertSuccessfulExecutionAsync(result, "search --no-cache");
+            Assert.True(await fixture.FileExists(releasesPath), "Expected --no-cache search to create releases.json when no cache exists.");
+
+            var content = await fixture.ReadFile(releasesPath);
+            using var document = JsonDocument.Parse(content);
+            Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
+            Assert.Contains(document.RootElement.EnumerateObject(), property => property.Value.TryGetProperty("stable", out _));
+        }
+        finally
+        {
+            await fixture.ExecuteShellCommand("rm", ["-rf", home]);
+        }
+    }
+
+    [Fact]
+    public async Task SearchCommandNoCacheRefreshesSeededReleasesJson()
+    {
+        var home = $"/tmp/fgvm-no-cache-refresh-{Guid.NewGuid():N}";
+        var root = $"{home}/fgvm";
+        var releasesPath = $"{root}/releases.json";
+
+        try
+        {
+            await fixture.ExecuteShellCommand("rm", ["-rf", home]);
+            await fixture.ExecuteShellCommand("mkdir", ["-p", root]);
+            await fixture.ExecuteShellCommand("sh", [
+                "-c",
+                $"cat > {releasesPath} << 'EOF'\n{{\"4.999\":{{\"stable\":{{}}}}}}\nEOF"
+            ]);
+
+            var cachedSearch = await fixture.ExecuteShellCommand("sh", ["-c", $"FGVM_HOME={home} {fixture.FgvmPath} search --json 4.999"]);
+            await fixture.AssertSuccessfulExecutionAsync(cachedSearch, "cached search");
+            Assert.Contains("4.999-stable", cachedSearch.Stdout);
+
+            var refreshedSearch = await fixture.ExecuteShellCommand("sh", ["-c", $"FGVM_HOME={home} {fixture.FgvmPath} search --no-cache --json 4.999"]);
+            await fixture.AssertSuccessfulExecutionAsync(refreshedSearch, "search --no-cache");
+            Assert.DoesNotContain("4.999-stable", refreshedSearch.Stdout);
+
+            var content = await fixture.ReadFile(releasesPath);
+            Assert.DoesNotContain("4.999-stable", content);
+
+            using var document = JsonDocument.Parse(content);
+            Assert.Equal(JsonValueKind.Object, document.RootElement.ValueKind);
+            Assert.Contains(document.RootElement.EnumerateObject(), property => property.Value.TryGetProperty("stable", out _));
+        }
+        finally
+        {
+            await fixture.ExecuteShellCommand("rm", ["-rf", home]);
+        }
+    }
+
+    [Fact]
     public async Task ListCommandDisplaysOutput()
     {
         var result = await fixture.ExecuteCommand(["list"]);

--- a/Fgvm.Tests.EndToEnd/Fgvm.Tests.EndToEnd.csproj
+++ b/Fgvm.Tests.EndToEnd/Fgvm.Tests.EndToEnd.csproj
@@ -9,12 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-        <PackageReference Include="Testcontainers" Version="4.10.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
+        <PackageReference Include="Testcontainers" Version="4.11.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>

--- a/Fgvm.Tests/Command/ListCommandTests.cs
+++ b/Fgvm.Tests/Command/ListCommandTests.cs
@@ -90,7 +90,7 @@ public sealed class ListCommandTests
         var mock = new Mock<IPathService>();
         mock.SetupGet(x => x.RootPath).Returns(rootPath);
         mock.SetupGet(x => x.ConfigPath).Returns(Path.Combine(rootPath, "fgvm.ini"));
-        mock.SetupGet(x => x.ReleasesPath).Returns(Path.Combine(rootPath, ".releases"));
+        mock.SetupGet(x => x.ReleasesPath).Returns(Path.Combine(rootPath, "releases.json"));
         mock.SetupGet(x => x.BinPath).Returns(binPath);
         mock.SetupGet(x => x.SymlinkPath).Returns(Path.Combine(binPath, "godot"));
         mock.SetupGet(x => x.MacAppSymlinkPath).Returns(Path.Combine(binPath, "Godot.app"));

--- a/Fgvm.Tests/Command/LogsCommandTests.cs
+++ b/Fgvm.Tests/Command/LogsCommandTests.cs
@@ -120,7 +120,7 @@ public sealed class LogsCommandTests : IDisposable
         mock.SetupGet(x => x.LogPath).Returns(logPath);
         mock.SetupGet(x => x.RootPath).Returns(rootPath);
         mock.SetupGet(x => x.ConfigPath).Returns(Path.Combine(rootPath, "fgvm.ini"));
-        mock.SetupGet(x => x.ReleasesPath).Returns(Path.Combine(rootPath, ".releases"));
+        mock.SetupGet(x => x.ReleasesPath).Returns(Path.Combine(rootPath, "releases.json"));
         mock.SetupGet(x => x.BinPath).Returns(binPath);
         mock.SetupGet(x => x.SymlinkPath).Returns(Path.Combine(binPath, "godot"));
         mock.SetupGet(x => x.MacAppSymlinkPath).Returns(Path.Combine(binPath, "Godot.app"));

--- a/Fgvm.Tests/Command/RemoveCommandTests.cs
+++ b/Fgvm.Tests/Command/RemoveCommandTests.cs
@@ -25,7 +25,7 @@ public class RemoveCommandTests
         _mockPathService.Setup(x => x.SymlinkPath).Returns("/test/symlink");
         _mockPathService.Setup(x => x.LogPath).Returns("/test/logs");
         _mockPathService.Setup(x => x.ConfigPath).Returns("/test/config");
-        _mockPathService.Setup(x => x.ReleasesPath).Returns("/test/releases");
+        _mockPathService.Setup(x => x.ReleasesPath).Returns("/test/releases.json");
         _mockPathService.Setup(x => x.BinPath).Returns("/test/bin");
         _mockPathService.Setup(x => x.MacAppSymlinkPath).Returns("/test/bin/Godot.app");
 

--- a/Fgvm.Tests/Command/SearchCommandTests.cs
+++ b/Fgvm.Tests/Command/SearchCommandTests.cs
@@ -19,7 +19,7 @@ public sealed class SearchCommandTests
     {
         var releases = new[] { "4.5-stable-standard", "4.5-stable-mono" };
         var releaseManager = new Mock<IReleaseManager>();
-        releaseManager.Setup(x => x.SearchRemoteReleases(It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+        releaseManager.Setup(x => x.SearchRemoteReleases(It.IsAny<string[]>(), It.IsAny<ReleaseFetchMode>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(releases));
 
         var command = CreateCommand(releaseManager.Object, out var console);
@@ -40,7 +40,7 @@ public sealed class SearchCommandTests
     {
         var releases = new[] { "4.5-stable-standard" };
         var releaseManager = new Mock<IReleaseManager>();
-        releaseManager.Setup(x => x.SearchRemoteReleases(It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+        releaseManager.Setup(x => x.SearchRemoteReleases(It.IsAny<string[]>(), It.IsAny<ReleaseFetchMode>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(releases));
 
         var command = CreateCommand(releaseManager.Object, out var console);
@@ -52,13 +52,29 @@ public sealed class SearchCommandTests
         Assert.Contains("List Of Available Versions", output);
     }
 
+    [Fact]
+    public async Task SearchCommand_NoCache_ForcesRemoteFetch()
+    {
+        var releaseManager = new Mock<IReleaseManager>();
+        releaseManager.Setup(x => x.SearchRemoteReleases(It.IsAny<string[]>(), ReleaseFetchMode.ForceRemote, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success([]));
+
+        var command = CreateCommand(releaseManager.Object, out _);
+
+        await command.Search(noCache: true);
+
+        releaseManager.Verify(
+            x => x.SearchRemoteReleases(It.IsAny<string[]>(), ReleaseFetchMode.ForceRemote, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private static SearchCommand CreateCommand(IReleaseManager releaseManager, out TestConsole console)
     {
         var pathServiceMock = new Mock<IPathService>();
         var rootPath = Path.Combine(Path.GetTempPath(), "fgvm-search-tests");
         pathServiceMock.SetupGet(x => x.RootPath).Returns(rootPath);
         pathServiceMock.SetupGet(x => x.ConfigPath).Returns(Path.Combine(rootPath, "fgvm.ini"));
-        pathServiceMock.SetupGet(x => x.ReleasesPath).Returns(Path.Combine(rootPath, ".releases"));
+        pathServiceMock.SetupGet(x => x.ReleasesPath).Returns(Path.Combine(rootPath, "releases.json"));
         pathServiceMock.SetupGet(x => x.BinPath).Returns(Path.Combine(rootPath, "bin"));
         pathServiceMock.SetupGet(x => x.SymlinkPath).Returns(Path.Combine(rootPath, "bin", "godot"));
         pathServiceMock.SetupGet(x => x.MacAppSymlinkPath).Returns(Path.Combine(rootPath, "bin", "Godot.app"));

--- a/Fgvm.Tests/Fgvm.Tests.csproj
+++ b/Fgvm.Tests/Fgvm.Tests.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="10.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FsCheck.Xunit" Version="3.3.2"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+        <PackageReference Include="FsCheck.Xunit" Version="3.3.3"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1"/>
         <PackageReference Include="Moq" Version="4.20.72"/>
-        <PackageReference Include="Spectre.Console.Testing" Version="0.54.0"/>
+        <PackageReference Include="Spectre.Console.Testing" Version="0.55.2"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <PrivateAssets>all</PrivateAssets>

--- a/Fgvm.Tests/Godot/DownloadClientTests.cs
+++ b/Fgvm.Tests/Godot/DownloadClientTests.cs
@@ -109,6 +109,50 @@ public class DownloadClientTests
     }
 
     [Fact]
+    public async Task GetReleaseManifest_GitHubSucceeds_ReturnsManifest()
+    {
+        var release = Release.TryParse("4.2-dev2-standard")!;
+        var gitHubMockHandler = new Mock<HttpMessageHandler>();
+        gitHubMockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(request =>
+                    request.RequestUri!.ToString() == "https://raw.githubusercontent.com/godotengine/godot-builds/main/releases/godot-4.2-dev2.json"),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+            """
+            {
+              "name": "4.2-dev2",
+              "version": "4.2",
+              "status": "dev2",
+              "release_date": 123,
+              "git_reference": "abc123",
+              "files": [
+                {
+                  "filename": "Godot_v4.2-dev2_macos.universal.zip",
+                  "checksum": "hash"
+                }
+              ]
+            }
+            """)
+            });
+        var gitHubClient = new GitHubClient(new HttpClient(gitHubMockHandler.Object), CreateMockConfiguration(), _mockGitHubLogger.Object);
+        var tuxFamilyClient = new TuxFamilyClient(new HttpClient(new Mock<HttpMessageHandler>().Object), _mockTuxFamilyLogger.Object);
+        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockLogger.Object);
+
+        var result = await downloadClient.GetReleaseManifest(release, CancellationToken.None);
+
+        var success = Assert.IsType<Result<GodotReleaseManifest, NetworkError>.Success>(result);
+        Assert.Equal("4.2-dev2", success.Value.Name);
+        Assert.Equal(123, success.Value.ReleaseDate);
+        Assert.Single(success.Value.Files);
+        Assert.Equal("hash", success.Value.Files[0].Checksum);
+    }
+
+    [Fact]
     public async Task GetZipFile_GitHubSucceeds_ReturnsSuccess()
     {
         var gitHubMockHandler = CreateMockHttpHandler(HttpStatusCode.OK, "zip");

--- a/Fgvm.Tests/Godot/DownloadClientTests.cs
+++ b/Fgvm.Tests/Godot/DownloadClientTests.cs
@@ -1,4 +1,3 @@
-using Fgvm.Environment;
 using Fgvm.Godot;
 using Fgvm.Types;
 using Microsoft.Extensions.Configuration;
@@ -13,7 +12,6 @@ public class DownloadClientTests
 {
     private readonly Mock<ILogger<GitHubClient>> _mockGitHubLogger;
     private readonly Mock<ILogger<DownloadClient>> _mockLogger;
-    private readonly Mock<IPathService> _mockPathService;
     private readonly Mock<ILogger<TuxFamilyClient>> _mockTuxFamilyLogger;
     private readonly Release _testRelease;
 
@@ -22,9 +20,6 @@ public class DownloadClientTests
         _mockLogger = new Mock<ILogger<DownloadClient>>();
         _mockGitHubLogger = new Mock<ILogger<GitHubClient>>();
         _mockTuxFamilyLogger = new Mock<ILogger<TuxFamilyClient>>();
-        _mockPathService = new Mock<IPathService>();
-        _mockPathService.Setup(x => x.ReleasesPath).Returns("/tmp/releases");
-
         _testRelease = new Release(4, 3, "linux_x86_64", 0, ReleaseType.Stable());
     }
 
@@ -36,7 +31,7 @@ public class DownloadClientTests
         var httpClient = new HttpClient(mockHttpHandler.Object);
         var gitHubClient = new GitHubClient(httpClient, CreateMockConfiguration(), _mockGitHubLogger.Object);
         var tuxFamilyClient = new TuxFamilyClient(new HttpClient(new Mock<HttpMessageHandler>().Object), _mockTuxFamilyLogger.Object);
-        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockPathService.Object, _mockLogger.Object);
+        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockLogger.Object);
 
         var result = await downloadClient.GetSha512(_testRelease, CancellationToken.None);
 
@@ -53,7 +48,7 @@ public class DownloadClientTests
 
         var gitHubClient = new GitHubClient(new HttpClient(gitHubMockHandler.Object), CreateMockConfiguration(), _mockGitHubLogger.Object);
         var tuxFamilyClient = new TuxFamilyClient(new HttpClient(tuxFamilyMockHandler.Object), _mockTuxFamilyLogger.Object);
-        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockPathService.Object, _mockLogger.Object);
+        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockLogger.Object);
 
         var result = await downloadClient.GetSha512(_testRelease, CancellationToken.None);
 
@@ -69,7 +64,7 @@ public class DownloadClientTests
 
         var gitHubClient = new GitHubClient(new HttpClient(gitHubMockHandler.Object), CreateMockConfiguration(), _mockGitHubLogger.Object);
         var tuxFamilyClient = new TuxFamilyClient(new HttpClient(tuxFamilyMockHandler.Object), _mockTuxFamilyLogger.Object);
-        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockPathService.Object, _mockLogger.Object);
+        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockLogger.Object);
 
         var result = await downloadClient.GetSha512(_testRelease, CancellationToken.None);
 
@@ -87,7 +82,7 @@ public class DownloadClientTests
 
         var gitHubClient = new GitHubClient(new HttpClient(gitHubMockHandler.Object), CreateMockConfiguration(), _mockGitHubLogger.Object);
         var tuxFamilyClient = new TuxFamilyClient(new HttpClient(tuxFamilyMockHandler.Object), _mockTuxFamilyLogger.Object);
-        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockPathService.Object, _mockLogger.Object);
+        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockLogger.Object);
 
         var result = await downloadClient.GetSha512(_testRelease, CancellationToken.None);
 
@@ -103,7 +98,7 @@ public class DownloadClientTests
 
         var gitHubClient = new GitHubClient(new HttpClient(gitHubMockHandler.Object), CreateMockConfiguration(), _mockGitHubLogger.Object);
         var tuxFamilyClient = new TuxFamilyClient(new HttpClient(tuxFamilyMockHandler.Object), _mockTuxFamilyLogger.Object);
-        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockPathService.Object, _mockLogger.Object);
+        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockLogger.Object);
 
         var result = await downloadClient.GetSha512(_testRelease, CancellationToken.None);
 
@@ -111,6 +106,56 @@ public class DownloadClientTests
         var allFailed = Assert.IsType<NetworkError.AllSourcesFailed>(failure.Error);
         Assert.Equal(2, allFailed.Errors.Count);
         Assert.All(allFailed.Errors, error => Assert.IsType<NetworkError.ConnectionFailure>(error));
+    }
+
+    [Fact]
+    public async Task GetZipFile_GitHubSucceeds_ReturnsSuccess()
+    {
+        var gitHubMockHandler = CreateMockHttpHandler(HttpStatusCode.OK, "zip");
+        var tuxFamilyMockHandler = CreateMockHttpHandler(HttpStatusCode.NotFound, "not found");
+
+        var gitHubClient = new GitHubClient(new HttpClient(gitHubMockHandler.Object), CreateMockConfiguration(), _mockGitHubLogger.Object);
+        var tuxFamilyClient = new TuxFamilyClient(new HttpClient(tuxFamilyMockHandler.Object), _mockTuxFamilyLogger.Object);
+        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockLogger.Object);
+
+        var result = await downloadClient.GetZipFile(_testRelease.ZipFileName, _testRelease, CancellationToken.None);
+
+        var success = Assert.IsType<Result<HttpResponseMessage, NetworkError>.Success>(result);
+        Assert.Equal(HttpStatusCode.OK, success.Value.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetZipFile_GitHubFails_TuxFamilySucceeds_ReturnsSuccess()
+    {
+        var gitHubMockHandler = CreateMockHttpHandler(HttpStatusCode.ServiceUnavailable, "GitHub down");
+        var tuxFamilyMockHandler = CreateMockHttpHandler(HttpStatusCode.OK, "zip");
+
+        var gitHubClient = new GitHubClient(new HttpClient(gitHubMockHandler.Object), CreateMockConfiguration(), _mockGitHubLogger.Object);
+        var tuxFamilyClient = new TuxFamilyClient(new HttpClient(tuxFamilyMockHandler.Object), _mockTuxFamilyLogger.Object);
+        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockLogger.Object);
+
+        var result = await downloadClient.GetZipFile(_testRelease.ZipFileName, _testRelease, CancellationToken.None);
+
+        var success = Assert.IsType<Result<HttpResponseMessage, NetworkError>.Success>(result);
+        Assert.Equal(HttpStatusCode.OK, success.Value.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetZipFile_BothFail_ReturnsAllSourcesFailed()
+    {
+        var gitHubMockHandler = CreateMockHttpHandler(HttpStatusCode.ServiceUnavailable, "GitHub down");
+        var tuxFamilyMockHandler = CreateMockHttpHandler(HttpStatusCode.NotFound, "not found");
+
+        var gitHubClient = new GitHubClient(new HttpClient(gitHubMockHandler.Object), CreateMockConfiguration(), _mockGitHubLogger.Object);
+        var tuxFamilyClient = new TuxFamilyClient(new HttpClient(tuxFamilyMockHandler.Object), _mockTuxFamilyLogger.Object);
+        var downloadClient = new DownloadClient(gitHubClient, tuxFamilyClient, _mockLogger.Object);
+
+        var result = await downloadClient.GetZipFile(_testRelease.ZipFileName, _testRelease, CancellationToken.None);
+
+        var failure = Assert.IsType<Result<HttpResponseMessage, NetworkError>.Failure>(result);
+        var allFailed = Assert.IsType<NetworkError.AllSourcesFailed>(failure.Error);
+        Assert.Equal(_testRelease.ZipFileName, allFailed.Resource);
+        Assert.Equal(2, allFailed.Errors.Count);
     }
 
     private static Mock<HttpMessageHandler> CreateMockHttpHandler(HttpStatusCode statusCode, string content)

--- a/Fgvm.Tests/Godot/ReleaseCatalogTests.cs
+++ b/Fgvm.Tests/Godot/ReleaseCatalogTests.cs
@@ -30,13 +30,17 @@ public sealed class ReleaseCatalogTests : IDisposable
     {
         await WriteManifest(new ReleaseCatalogManifest
         {
-            ["4.4"] = new ReleaseCatalogVersion
+            LastUpdated = DateTimeOffset.UtcNow,
+            Releases =
             {
-                ["stable"] = []
-            },
-            ["4.3"] = new ReleaseCatalogVersion
-            {
-                ["stable"] = []
+                ["4.4"] = new ReleaseCatalogVersion
+                {
+                    ["stable"] = new ReleaseCatalogRelease()
+                },
+                ["4.3"] = new ReleaseCatalogVersion
+                {
+                    ["stable"] = new ReleaseCatalogRelease()
+                }
             }
         });
 
@@ -59,10 +63,11 @@ public sealed class ReleaseCatalogTests : IDisposable
         Assert.Equal(["4.4-stable", "4.5-dev1"], success.Value);
 
         var manifest = await ReadManifest();
-        Assert.Contains("4.4", manifest.Keys);
-        Assert.Contains("4.5", manifest.Keys);
-        Assert.Contains("stable", manifest["4.4"].Keys);
-        Assert.Contains("dev1", manifest["4.5"].Keys);
+        Assert.NotNull(manifest.LastUpdated);
+        Assert.Contains("4.4", manifest.Releases.Keys);
+        Assert.Contains("4.5", manifest.Releases.Keys);
+        Assert.Contains("stable", manifest.Releases["4.4"].Keys);
+        Assert.Contains("dev1", manifest.Releases["4.5"].Keys);
         Assert.True(File.Exists(_releasesPath));
     }
 
@@ -78,9 +83,9 @@ public sealed class ReleaseCatalogTests : IDisposable
         Assert.Equal(["4.4-stable"], success.Value);
 
         var manifest = await ReadManifest();
-        Assert.Single(manifest);
-        Assert.Single(manifest["4.4"]);
-        Assert.Contains("stable", manifest["4.4"].Keys);
+        Assert.Single(manifest.Releases);
+        Assert.Single(manifest.Releases["4.4"]);
+        Assert.Contains("stable", manifest.Releases["4.4"].Keys);
     }
 
     [Fact]
@@ -88,9 +93,13 @@ public sealed class ReleaseCatalogTests : IDisposable
     {
         await WriteManifest(new ReleaseCatalogManifest
         {
-            ["4.3"] = new ReleaseCatalogVersion
+            LastUpdated = DateTimeOffset.UtcNow,
+            Releases =
             {
-                ["stable"] = []
+                ["4.3"] = new ReleaseCatalogVersion
+                {
+                    ["stable"] = new ReleaseCatalogRelease()
+                }
             }
         });
 
@@ -117,12 +126,47 @@ public sealed class ReleaseCatalogTests : IDisposable
 
         var success = Assert.IsType<Result<string[], NetworkError>.Success>(result);
         Assert.Equal(["4.4-stable"], success.Value);
+
+        var manifest = await ReadManifest();
+        Assert.NotNull(manifest.LastUpdated);
+        Assert.Contains("4.4", manifest.Releases.Keys);
+    }
+
+    [Fact]
+    public async Task ReadReleaseIds_StaleLastUpdated_FetchesRemote()
+    {
+        await WriteManifest(new ReleaseCatalogManifest
+        {
+            LastUpdated = DateTimeOffset.UtcNow.AddDays(-2),
+            Releases =
+            {
+                ["4.3"] = new ReleaseCatalogVersion
+                {
+                    ["stable"] = new ReleaseCatalogRelease()
+                }
+            }
+        });
+
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["4.4-stable"]));
+
+        var result = await _catalog.ReadReleaseIds(ReleaseFetchMode.UseCache, CancellationToken.None);
+
+        var success = Assert.IsType<Result<string[], NetworkError>.Success>(result);
+        Assert.Equal(["4.4-stable"], success.Value);
+
+        var manifest = await ReadManifest();
+        Assert.DoesNotContain("4.3", manifest.Releases.Keys);
+        Assert.Contains("4.4", manifest.Releases.Keys);
     }
 
     [Fact]
     public async Task ReadReleaseIds_EmptyCache_FetchesRemote()
     {
-        await WriteManifest([]);
+        await WriteManifest(new ReleaseCatalogManifest
+        {
+            LastUpdated = DateTimeOffset.UtcNow
+        });
 
         _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["4.4-stable"]));
@@ -147,32 +191,54 @@ public sealed class ReleaseCatalogTests : IDisposable
     }
 
     [Fact]
+    public async Task ReadReleaseIds_WriteFailure_ReturnsFailure()
+    {
+        Directory.CreateDirectory(_releasesPath);
+
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["4.4-stable"]));
+
+        var result = await _catalog.ReadReleaseIds(ReleaseFetchMode.UseCache, CancellationToken.None);
+
+        var failure = Assert.IsType<Result<string[], NetworkError>.Failure>(result);
+        var error = Assert.IsType<NetworkError.ConnectionFailure>(failure.Error);
+        Assert.Contains("Failed to write release catalog", error.Message);
+    }
+
+    [Fact]
     public async Task ReadReleaseIds_RefreshPreservesExistingArtifactsForMatchingRelease()
     {
         await WriteManifest(new ReleaseCatalogManifest
         {
-            ["4.4"] = new ReleaseCatalogVersion
+            LastUpdated = DateTimeOffset.UtcNow,
+            Releases =
             {
-                ["stable"] = new ReleaseCatalogRelease
+                ["4.4"] = new ReleaseCatalogVersion
                 {
-                    ["macos.universal"] = new ReleaseCatalogTarget
+                    ["stable"] = new ReleaseCatalogRelease
                     {
-                        ["standard"] = new()
+                        Targets = new ReleaseCatalogTargets
                         {
-                            FileName = "Godot_v4.4-stable_macos.universal.zip",
-                            Sha512 = "abc"
-                        },
-                        ["mono"] = new()
-                        {
-                            FileName = "Godot_v4.4-stable_mono_macos.universal.zip",
-                            Sha512 = "def"
+                            ["macos.universal"] = new ReleaseCatalogTarget
+                            {
+                                ["standard"] = new()
+                                {
+                                    FileName = "Godot_v4.4-stable_macos.universal.zip",
+                                    Sha512 = "abc"
+                                },
+                                ["mono"] = new()
+                                {
+                                    FileName = "Godot_v4.4-stable_mono_macos.universal.zip",
+                                    Sha512 = "def"
+                                }
+                            }
                         }
                     }
+                },
+                ["4.3"] = new ReleaseCatalogVersion
+                {
+                    ["stable"] = new ReleaseCatalogRelease()
                 }
-            },
-            ["4.3"] = new ReleaseCatalogVersion
-            {
-                ["stable"] = []
             }
         });
 
@@ -184,30 +250,37 @@ public sealed class ReleaseCatalogTests : IDisposable
         Assert.IsType<Result<string[], NetworkError>.Success>(result);
 
         var manifest = await ReadManifest();
-        Assert.Contains("4.5", manifest.Keys);
-        Assert.Contains("4.4", manifest.Keys);
-        Assert.DoesNotContain("4.3", manifest.Keys);
-        Assert.Contains("stable", manifest["4.5"].Keys);
-        Assert.Contains("stable", manifest["4.4"].Keys);
-        Assert.Equal("abc", manifest["4.4"]["stable"]["macos.universal"]["standard"].Sha512);
-        Assert.Equal("def", manifest["4.4"]["stable"]["macos.universal"]["mono"].Sha512);
+        Assert.Contains("4.5", manifest.Releases.Keys);
+        Assert.Contains("4.4", manifest.Releases.Keys);
+        Assert.DoesNotContain("4.3", manifest.Releases.Keys);
+        Assert.Contains("stable", manifest.Releases["4.5"].Keys);
+        Assert.Contains("stable", manifest.Releases["4.4"].Keys);
+        Assert.Equal("abc", manifest.Releases["4.4"]["stable"].Targets["macos.universal"]["standard"].Sha512);
+        Assert.Equal("def", manifest.Releases["4.4"]["stable"].Targets["macos.universal"]["mono"].Sha512);
     }
 
     [Fact]
-    public async Task FindArtifact_ReturnsMatchingReleaseTargetAndRuntime()
+    public async Task FindOrHydrateArtifact_ReturnsCachedReleaseTargetAndRuntime()
     {
         await WriteManifest(new ReleaseCatalogManifest
         {
-            ["4.4"] = new ReleaseCatalogVersion
+            LastUpdated = DateTimeOffset.UtcNow,
+            Releases =
             {
-                ["stable"] = new ReleaseCatalogRelease
+                ["4.4"] = new ReleaseCatalogVersion
                 {
-                    ["macos.universal"] = new ReleaseCatalogTarget
+                    ["stable"] = new ReleaseCatalogRelease
                     {
-                        ["standard"] = new()
+                        Targets = new ReleaseCatalogTargets
                         {
-                            FileName = "Godot_v4.4-stable_macos.universal.zip",
-                            Sha512 = "abc"
+                            ["macos.universal"] = new ReleaseCatalogTarget
+                            {
+                                ["standard"] = new()
+                                {
+                                    FileName = "Godot_v4.4-stable_macos.universal.zip",
+                                    Sha512 = "abc"
+                                }
+                            }
                         }
                     }
                 }
@@ -219,28 +292,37 @@ public sealed class ReleaseCatalogTests : IDisposable
             PlatformString = "macos.universal"
         };
 
-        var artifact = await _catalog.FindArtifact(release, CancellationToken.None);
+        var result = await _catalog.FindOrHydrateArtifact(release, CancellationToken.None);
 
-        Assert.NotNull(artifact);
+        var success = Assert.IsType<Result<ReleaseArtifact, NetworkError>.Success>(result);
+        var artifact = success.Value;
         Assert.Equal("Godot_v4.4-stable_macos.universal.zip", artifact.FileName);
         Assert.Equal("abc", artifact.Sha512);
+        _downloadClient.Verify(x => x.GetReleaseManifest(It.IsAny<Release>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task FindArtifact_ReturnsNullWhenRuntimeIsMissing()
+    public async Task FindOrHydrateArtifact_HydratesWhenCachedRuntimeIsMissing()
     {
         await WriteManifest(new ReleaseCatalogManifest
         {
-            ["4.4"] = new ReleaseCatalogVersion
+            LastUpdated = DateTimeOffset.UtcNow,
+            Releases =
             {
-                ["stable"] = new ReleaseCatalogRelease
+                ["4.4"] = new ReleaseCatalogVersion
                 {
-                    ["macos.universal"] = new ReleaseCatalogTarget
+                    ["stable"] = new ReleaseCatalogRelease
                     {
-                        ["standard"] = new()
+                        Targets = new ReleaseCatalogTargets
                         {
-                            FileName = "Godot_v4.4-stable_macos.universal.zip",
-                            Sha512 = "abc"
+                            ["macos.universal"] = new ReleaseCatalogTarget
+                            {
+                                ["standard"] = new()
+                                {
+                                    FileName = "Godot_v4.4-stable_macos.universal.zip",
+                                    Sha512 = "abc"
+                                }
+                            }
                         }
                     }
                 }
@@ -252,19 +334,41 @@ public sealed class ReleaseCatalogTests : IDisposable
             PlatformString = "mono_macos.universal"
         };
 
-        var artifact = await _catalog.FindArtifact(release, CancellationToken.None);
+        _downloadClient.Setup(x => x.GetReleaseManifest(release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<GodotReleaseManifest, NetworkError>.Success(new GodotReleaseManifest
+            {
+                Name = "4.4-stable",
+                Version = "4.4",
+                Status = "stable",
+                Files =
+                [
+                    new()
+                    {
+                        FileName = "Godot_v4.4-stable_mono_macos.universal.zip",
+                        Checksum = "def"
+                    }
+                ]
+            }));
 
-        Assert.Null(artifact);
+        var result = await _catalog.FindOrHydrateArtifact(release, CancellationToken.None);
+
+        var success = Assert.IsType<Result<ReleaseArtifact, NetworkError>.Success>(result);
+        Assert.Equal("Godot_v4.4-stable_mono_macos.universal.zip", success.Value.FileName);
+        Assert.Equal("def", success.Value.Sha512);
     }
 
     [Fact]
-    public async Task RecordArtifact_NormalizesMonoTargetAndWritesRuntimeArtifact()
+    public async Task FindOrHydrateArtifact_IngestsManifestFilesAndNormalizesMonoTarget()
     {
         await WriteManifest(new ReleaseCatalogManifest
         {
-            ["4.4"] = new ReleaseCatalogVersion
+            LastUpdated = DateTimeOffset.UtcNow,
+            Releases =
             {
-                ["stable"] = []
+                ["4.4"] = new ReleaseCatalogVersion
+                {
+                    ["stable"] = new ReleaseCatalogRelease()
+                }
             }
         });
 
@@ -273,28 +377,254 @@ public sealed class ReleaseCatalogTests : IDisposable
             PlatformString = "mono_macos.universal"
         };
 
-        await _catalog.RecordArtifact(release, "Godot_v4.4-stable_mono_macos.universal.zip", "def", CancellationToken.None);
+        _downloadClient.Setup(x => x.GetReleaseManifest(release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<GodotReleaseManifest, NetworkError>.Success(new GodotReleaseManifest
+            {
+                Name = "4.4-stable",
+                Version = "4.4",
+                Status = "stable",
+                ReleaseDate = 123,
+                GitReference = "abc123",
+                Files =
+                [
+                    new()
+                    {
+                        FileName = "Godot_v4.4-stable_macos.universal.zip",
+                        Checksum = "standard"
+                    },
+                    new()
+                    {
+                        FileName = "Godot_v4.4-stable_mono_macos.universal.zip",
+                        Checksum = "mono"
+                    },
+                    new()
+                    {
+                        FileName = "Godot_v4.4-stable_export_templates.tpz",
+                        Checksum = "templates"
+                    }
+                ]
+            }));
 
+        var result = await _catalog.FindOrHydrateArtifact(release, CancellationToken.None);
+
+        var success = Assert.IsType<Result<ReleaseArtifact, NetworkError>.Success>(result);
+        Assert.NotNull(success.Value);
+        Assert.Equal("mono", success.Value.Sha512);
         var manifest = await ReadManifest();
-        var artifact = manifest["4.4"]["stable"]["macos.universal"]["mono"];
+        var catalogRelease = manifest.Releases["4.4"]["stable"];
+        var artifact = catalogRelease.Targets["macos.universal"]["mono"];
         Assert.Equal("Godot_v4.4-stable_mono_macos.universal.zip", artifact.FileName);
-        Assert.Equal("def", artifact.Sha512);
+        Assert.Equal("mono", artifact.Sha512);
+        Assert.Equal(123, catalogRelease.ReleaseDate);
+        Assert.Equal("abc123", catalogRelease.GitReference);
+        Assert.Equal("templates", catalogRelease.Files["Godot_v4.4-stable_export_templates.tpz"].Sha512);
+        _downloadClient.Verify(x => x.GetSha512(It.IsAny<Release>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task RecordArtifact_NormalizesWindowsExecutableTarget()
+    public async Task FindOrHydrateArtifact_FallsBackToSha512SumsWhenManifestFilesAreEmpty()
+    {
+        var hostHash = new string('a', 128);
+        var otherHash = new string('b', 128);
+        var release = Release.TryParse("3.2-stable-standard")! with
+        {
+            PlatformString = "osx.64"
+        };
+
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["3.2-stable"]));
+
+        _downloadClient.Setup(x => x.GetReleaseManifest(release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<GodotReleaseManifest, NetworkError>.Success(new GodotReleaseManifest
+            {
+                Name = "3.2-stable",
+                Version = "3.2",
+                Status = "stable",
+                Files = []
+            }));
+
+        _downloadClient.Setup(x => x.GetSha512(release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<string, NetworkError>.Success(
+                $"{hostHash}  Godot_v3.2-stable_osx.64.zip\n{otherHash}  Godot_v3.2-stable_x11.64.zip"));
+
+        var result = await _catalog.FindOrHydrateArtifact(release, CancellationToken.None);
+
+        var success = Assert.IsType<Result<ReleaseArtifact, NetworkError>.Success>(result);
+        Assert.NotNull(success.Value);
+        Assert.Equal("Godot_v3.2-stable_osx.64.zip", success.Value.FileName);
+        Assert.Equal(hostHash, success.Value.Sha512);
+
+        var manifest = await ReadManifest();
+        Assert.Equal(otherHash, manifest.Releases["3.2"]["stable"].Targets["x11.64"]["standard"].Sha512);
+    }
+
+    [Fact]
+    public void ParseSha512SumsContent_IgnoresNonSha512Lines()
+    {
+        var validHash = new string('a', 128);
+        var artifacts = ReleaseCatalog.ParseSha512SumsContent(
+            $"""
+            <!DOCTYPE html>
+            not-a-sha Godot_v3.2-stable_osx.64.zip
+            {validHash}  Godot_v3.2-stable_x11.64.zip
+            """);
+
+        var artifact = Assert.Single(artifacts);
+        Assert.Equal("Godot_v3.2-stable_x11.64.zip", artifact.FileName);
+        Assert.Equal(validHash, artifact.Sha512);
+    }
+
+    [Fact]
+    public async Task FindOrHydrateArtifact_ReturnsInferredArtifactWhenEmptyManifestChecksumFallbackFails()
+    {
+        var release = Release.TryParse("3.2.1-stable-standard")! with
+        {
+            PlatformString = "osx.64"
+        };
+
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["3.2.1-stable"]));
+
+        _downloadClient.Setup(x => x.GetReleaseManifest(release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<GodotReleaseManifest, NetworkError>.Success(new GodotReleaseManifest
+            {
+                Name = "3.2.1-stable",
+                Version = "3.2.1",
+                Status = "stable",
+                Files = []
+            }));
+
+        _downloadClient.Setup(x => x.GetSha512(release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<string, NetworkError>.Failure(new NetworkError.ConnectionFailure("not found")));
+
+        var result = await _catalog.FindOrHydrateArtifact(release, CancellationToken.None);
+
+        var success = Assert.IsType<Result<ReleaseArtifact, NetworkError>.Success>(result);
+        Assert.Equal("Godot_v3.2.1-stable_osx.64.zip", success.Value.FileName);
+        Assert.Null(success.Value.Sha512);
+    }
+
+    [Fact]
+    public async Task FindOrHydrateArtifact_IngestsManifestFilesAndNormalizesWindowsExecutableTarget()
     {
         var release = Release.TryParse("4.4-stable-standard")! with
         {
             PlatformString = "win64.exe"
         };
 
-        await _catalog.RecordArtifact(release, "Godot_v4.4-stable_win64.exe.zip", "abc", CancellationToken.None);
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["4.4-stable"]));
 
+        _downloadClient.Setup(x => x.GetReleaseManifest(release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<GodotReleaseManifest, NetworkError>.Success(new GodotReleaseManifest
+            {
+                Name = "4.4-stable",
+                Version = "4.4",
+                Status = "stable",
+                Files =
+                [
+                    new()
+                    {
+                        FileName = "Godot_v4.4-stable_win64.exe.zip",
+                        Checksum = "abc"
+                    }
+                ]
+            }));
+
+        var result = await _catalog.FindOrHydrateArtifact(release, CancellationToken.None);
+
+        Assert.IsType<Result<ReleaseArtifact, NetworkError>.Success>(result);
         var manifest = await ReadManifest();
-        var artifact = manifest["4.4"]["stable"]["win64"]["standard"];
+        var artifact = manifest.Releases["4.4"]["stable"].Targets["win64"]["standard"];
         Assert.Equal("Godot_v4.4-stable_win64.exe.zip", artifact.FileName);
         Assert.Equal("abc", artifact.Sha512);
+    }
+
+    [Fact]
+    public async Task FindOrHydrateArtifact_PopulatedManifestMissingTarget_ReturnsFailure()
+    {
+        await WriteManifest(new ReleaseCatalogManifest
+        {
+            LastUpdated = DateTimeOffset.UtcNow,
+            Releases =
+            {
+                ["4.4"] = new ReleaseCatalogVersion
+                {
+                    ["stable"] = new ReleaseCatalogRelease()
+                }
+            }
+        });
+
+        var release = Release.TryParse("4.4-stable-standard")! with
+        {
+            PlatformString = "linux.x86_64"
+        };
+
+        _downloadClient.Setup(x => x.GetReleaseManifest(release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<GodotReleaseManifest, NetworkError>.Success(new GodotReleaseManifest
+            {
+                Name = "4.4-stable",
+                Version = "4.4",
+                Status = "stable",
+                Files =
+                [
+                    new()
+                    {
+                        FileName = "Godot_v4.4-stable_macos.universal.zip",
+                        Checksum = "abc"
+                    }
+                ]
+            }));
+
+        var result = await _catalog.FindOrHydrateArtifact(release, CancellationToken.None);
+
+        var failure = Assert.IsType<Result<ReleaseArtifact, NetworkError>.Failure>(result);
+        var error = Assert.IsType<NetworkError.ConnectionFailure>(failure.Error);
+        Assert.Contains("No artifact found", error.Message);
+    }
+
+    [Fact]
+    public async Task FindOrHydrateArtifact_DoesNotUpdateLastUpdatedWhenHydratingArtifactMetadata()
+    {
+        var lastUpdated = DateTimeOffset.UtcNow.AddHours(-3);
+        await WriteManifest(new ReleaseCatalogManifest
+        {
+            LastUpdated = lastUpdated,
+            Releases =
+            {
+                ["4.4"] = new ReleaseCatalogVersion
+                {
+                    ["stable"] = new ReleaseCatalogRelease()
+                }
+            }
+        });
+
+        var release = Release.TryParse("4.4-stable-standard")! with
+        {
+            PlatformString = "macos.universal"
+        };
+
+        _downloadClient.Setup(x => x.GetReleaseManifest(release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<GodotReleaseManifest, NetworkError>.Success(new GodotReleaseManifest
+            {
+                Name = "4.4-stable",
+                Version = "4.4",
+                Status = "stable",
+                Files =
+                [
+                    new()
+                    {
+                        FileName = "Godot_v4.4-stable_macos.universal.zip",
+                        Checksum = "abc"
+                    }
+                ]
+            }));
+
+        var result = await _catalog.FindOrHydrateArtifact(release, CancellationToken.None);
+
+        Assert.IsType<Result<ReleaseArtifact, NetworkError>.Success>(result);
+        var manifest = await ReadManifest();
+        Assert.Equal(lastUpdated, manifest.LastUpdated);
     }
 
     public void Dispose()
@@ -315,7 +645,8 @@ public sealed class ReleaseCatalogTests : IDisposable
     private async Task<ReleaseCatalogManifest> ReadManifest()
     {
         await using var stream = File.OpenRead(_releasesPath);
-        return await JsonSerializer.DeserializeAsync(stream, ReleaseCatalogJsonContext.Default.ReleaseCatalogManifest, CancellationToken.None)
-               ?? [];
+        var manifest = await JsonSerializer.DeserializeAsync(stream, ReleaseCatalogJsonContext.Default.ReleaseCatalogManifest, CancellationToken.None);
+        Assert.NotNull(manifest);
+        return manifest;
     }
 }

--- a/Fgvm.Tests/Godot/ReleaseCatalogTests.cs
+++ b/Fgvm.Tests/Godot/ReleaseCatalogTests.cs
@@ -1,0 +1,321 @@
+using Fgvm.Environment;
+using Fgvm.Godot;
+using Fgvm.Types;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Text.Json;
+
+namespace Fgvm.Tests.Godot;
+
+public sealed class ReleaseCatalogTests : IDisposable
+{
+    private readonly Mock<IDownloadClient> _downloadClient = new();
+    private readonly string _rootPath = Path.Combine(Path.GetTempPath(), "fgvm-release-catalog-tests", Guid.NewGuid().ToString("N"));
+    private readonly string _releasesPath;
+    private readonly ReleaseCatalog _catalog;
+
+    public ReleaseCatalogTests()
+    {
+        _releasesPath = Path.Combine(_rootPath, "releases.json");
+
+        var pathService = new Mock<IPathService>();
+        pathService.SetupGet(x => x.RootPath).Returns(_rootPath);
+        pathService.SetupGet(x => x.ReleasesPath).Returns(_releasesPath);
+
+        _catalog = new ReleaseCatalog(_downloadClient.Object, pathService.Object, NullLogger<ReleaseCatalog>.Instance);
+    }
+
+    [Fact]
+    public async Task ReadReleaseIds_UsesFreshReleasesJson()
+    {
+        await WriteManifest(new ReleaseCatalogManifest
+        {
+            ["4.4"] = new ReleaseCatalogVersion
+            {
+                ["stable"] = []
+            },
+            ["4.3"] = new ReleaseCatalogVersion
+            {
+                ["stable"] = []
+            }
+        });
+
+        var result = await _catalog.ReadReleaseIds(ReleaseFetchMode.UseCache, CancellationToken.None);
+
+        var success = Assert.IsType<Result<string[], NetworkError>.Success>(result);
+        Assert.Equal(["4.4-stable", "4.3-stable"], success.Value);
+        _downloadClient.Verify(x => x.ListReleases(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReadReleaseIds_MissingCache_FetchesRemoteAndWritesReleasesJson()
+    {
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["4.4-stable", "4.5-dev1"]));
+
+        var result = await _catalog.ReadReleaseIds(ReleaseFetchMode.UseCache, CancellationToken.None);
+
+        var success = Assert.IsType<Result<string[], NetworkError>.Success>(result);
+        Assert.Equal(["4.4-stable", "4.5-dev1"], success.Value);
+
+        var manifest = await ReadManifest();
+        Assert.Contains("4.4", manifest.Keys);
+        Assert.Contains("4.5", manifest.Keys);
+        Assert.Contains("stable", manifest["4.4"].Keys);
+        Assert.Contains("dev1", manifest["4.5"].Keys);
+        Assert.True(File.Exists(_releasesPath));
+    }
+
+    [Fact]
+    public async Task ReadReleaseIds_DeduplicatesRuntimeSpecificRemoteIds()
+    {
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["4.4-stable-standard", "4.4-stable-mono"]));
+
+        var result = await _catalog.ReadReleaseIds(ReleaseFetchMode.UseCache, CancellationToken.None);
+
+        var success = Assert.IsType<Result<string[], NetworkError>.Success>(result);
+        Assert.Equal(["4.4-stable"], success.Value);
+
+        var manifest = await ReadManifest();
+        Assert.Single(manifest);
+        Assert.Single(manifest["4.4"]);
+        Assert.Contains("stable", manifest["4.4"].Keys);
+    }
+
+    [Fact]
+    public async Task ReadReleaseIds_ForceRemote_IgnoresFreshCache()
+    {
+        await WriteManifest(new ReleaseCatalogManifest
+        {
+            ["4.3"] = new ReleaseCatalogVersion
+            {
+                ["stable"] = []
+            }
+        });
+
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["4.4-stable"]));
+
+        var result = await _catalog.ReadReleaseIds(ReleaseFetchMode.ForceRemote, CancellationToken.None);
+
+        var success = Assert.IsType<Result<string[], NetworkError>.Success>(result);
+        Assert.Equal(["4.4-stable"], success.Value);
+        _downloadClient.Verify(x => x.ListReleases(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ReadReleaseIds_InvalidCache_FetchesRemote()
+    {
+        Directory.CreateDirectory(_rootPath);
+        await File.WriteAllTextAsync(_releasesPath, "{ nope", CancellationToken.None);
+
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["4.4-stable"]));
+
+        var result = await _catalog.ReadReleaseIds(ReleaseFetchMode.UseCache, CancellationToken.None);
+
+        var success = Assert.IsType<Result<string[], NetworkError>.Success>(result);
+        Assert.Equal(["4.4-stable"], success.Value);
+    }
+
+    [Fact]
+    public async Task ReadReleaseIds_EmptyCache_FetchesRemote()
+    {
+        await WriteManifest([]);
+
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["4.4-stable"]));
+
+        var result = await _catalog.ReadReleaseIds(ReleaseFetchMode.UseCache, CancellationToken.None);
+
+        var success = Assert.IsType<Result<string[], NetworkError>.Success>(result);
+        Assert.Equal(["4.4-stable"], success.Value);
+    }
+
+    [Fact]
+    public async Task ReadReleaseIds_RemoteFailureWithoutCache_ReturnsFailure()
+    {
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Failure(new NetworkError.ConnectionFailure("offline")));
+
+        var result = await _catalog.ReadReleaseIds(ReleaseFetchMode.UseCache, CancellationToken.None);
+
+        var failure = Assert.IsType<Result<string[], NetworkError>.Failure>(result);
+        var error = Assert.IsType<NetworkError.ConnectionFailure>(failure.Error);
+        Assert.Equal("offline", error.Message);
+    }
+
+    [Fact]
+    public async Task ReadReleaseIds_RefreshPreservesExistingArtifactsForMatchingRelease()
+    {
+        await WriteManifest(new ReleaseCatalogManifest
+        {
+            ["4.4"] = new ReleaseCatalogVersion
+            {
+                ["stable"] = new ReleaseCatalogRelease
+                {
+                    ["macos.universal"] = new ReleaseCatalogTarget
+                    {
+                        ["standard"] = new()
+                        {
+                            FileName = "Godot_v4.4-stable_macos.universal.zip",
+                            Sha512 = "abc"
+                        },
+                        ["mono"] = new()
+                        {
+                            FileName = "Godot_v4.4-stable_mono_macos.universal.zip",
+                            Sha512 = "def"
+                        }
+                    }
+                }
+            },
+            ["4.3"] = new ReleaseCatalogVersion
+            {
+                ["stable"] = []
+            }
+        });
+
+        _downloadClient.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<IEnumerable<string>, NetworkError>.Success(["4.5-stable", "4.4-stable"]));
+
+        var result = await _catalog.ReadReleaseIds(ReleaseFetchMode.ForceRemote, CancellationToken.None);
+
+        Assert.IsType<Result<string[], NetworkError>.Success>(result);
+
+        var manifest = await ReadManifest();
+        Assert.Contains("4.5", manifest.Keys);
+        Assert.Contains("4.4", manifest.Keys);
+        Assert.DoesNotContain("4.3", manifest.Keys);
+        Assert.Contains("stable", manifest["4.5"].Keys);
+        Assert.Contains("stable", manifest["4.4"].Keys);
+        Assert.Equal("abc", manifest["4.4"]["stable"]["macos.universal"]["standard"].Sha512);
+        Assert.Equal("def", manifest["4.4"]["stable"]["macos.universal"]["mono"].Sha512);
+    }
+
+    [Fact]
+    public async Task FindArtifact_ReturnsMatchingReleaseTargetAndRuntime()
+    {
+        await WriteManifest(new ReleaseCatalogManifest
+        {
+            ["4.4"] = new ReleaseCatalogVersion
+            {
+                ["stable"] = new ReleaseCatalogRelease
+                {
+                    ["macos.universal"] = new ReleaseCatalogTarget
+                    {
+                        ["standard"] = new()
+                        {
+                            FileName = "Godot_v4.4-stable_macos.universal.zip",
+                            Sha512 = "abc"
+                        }
+                    }
+                }
+            }
+        });
+
+        var release = Release.TryParse("4.4-stable-standard")! with
+        {
+            PlatformString = "macos.universal"
+        };
+
+        var artifact = await _catalog.FindArtifact(release, CancellationToken.None);
+
+        Assert.NotNull(artifact);
+        Assert.Equal("Godot_v4.4-stable_macos.universal.zip", artifact.FileName);
+        Assert.Equal("abc", artifact.Sha512);
+    }
+
+    [Fact]
+    public async Task FindArtifact_ReturnsNullWhenRuntimeIsMissing()
+    {
+        await WriteManifest(new ReleaseCatalogManifest
+        {
+            ["4.4"] = new ReleaseCatalogVersion
+            {
+                ["stable"] = new ReleaseCatalogRelease
+                {
+                    ["macos.universal"] = new ReleaseCatalogTarget
+                    {
+                        ["standard"] = new()
+                        {
+                            FileName = "Godot_v4.4-stable_macos.universal.zip",
+                            Sha512 = "abc"
+                        }
+                    }
+                }
+            }
+        });
+
+        var release = Release.TryParse("4.4-stable-mono")! with
+        {
+            PlatformString = "mono_macos.universal"
+        };
+
+        var artifact = await _catalog.FindArtifact(release, CancellationToken.None);
+
+        Assert.Null(artifact);
+    }
+
+    [Fact]
+    public async Task RecordArtifact_NormalizesMonoTargetAndWritesRuntimeArtifact()
+    {
+        await WriteManifest(new ReleaseCatalogManifest
+        {
+            ["4.4"] = new ReleaseCatalogVersion
+            {
+                ["stable"] = []
+            }
+        });
+
+        var release = Release.TryParse("4.4-stable-mono")! with
+        {
+            PlatformString = "mono_macos.universal"
+        };
+
+        await _catalog.RecordArtifact(release, "Godot_v4.4-stable_mono_macos.universal.zip", "def", CancellationToken.None);
+
+        var manifest = await ReadManifest();
+        var artifact = manifest["4.4"]["stable"]["macos.universal"]["mono"];
+        Assert.Equal("Godot_v4.4-stable_mono_macos.universal.zip", artifact.FileName);
+        Assert.Equal("def", artifact.Sha512);
+    }
+
+    [Fact]
+    public async Task RecordArtifact_NormalizesWindowsExecutableTarget()
+    {
+        var release = Release.TryParse("4.4-stable-standard")! with
+        {
+            PlatformString = "win64.exe"
+        };
+
+        await _catalog.RecordArtifact(release, "Godot_v4.4-stable_win64.exe.zip", "abc", CancellationToken.None);
+
+        var manifest = await ReadManifest();
+        var artifact = manifest["4.4"]["stable"]["win64"]["standard"];
+        Assert.Equal("Godot_v4.4-stable_win64.exe.zip", artifact.FileName);
+        Assert.Equal("abc", artifact.Sha512);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_rootPath))
+        {
+            Directory.Delete(_rootPath, true);
+        }
+    }
+
+    private async Task WriteManifest(ReleaseCatalogManifest manifest)
+    {
+        Directory.CreateDirectory(_rootPath);
+        await using var stream = File.Create(_releasesPath);
+        await JsonSerializer.SerializeAsync(stream, manifest, ReleaseCatalogJsonContext.Default.ReleaseCatalogManifest, CancellationToken.None);
+    }
+
+    private async Task<ReleaseCatalogManifest> ReadManifest()
+    {
+        await using var stream = File.OpenRead(_releasesPath);
+        return await JsonSerializer.DeserializeAsync(stream, ReleaseCatalogJsonContext.Default.ReleaseCatalogManifest, CancellationToken.None)
+               ?? [];
+    }
+}

--- a/Fgvm.Tests/Godot/ReleaseManager/FindCompatibleVersionTests.cs
+++ b/Fgvm.Tests/Godot/ReleaseManager/FindCompatibleVersionTests.cs
@@ -1,3 +1,6 @@
+using Fgvm.Godot;
+using Fgvm.Types;
+
 namespace Fgvm.Tests.Godot.ReleaseManager;
 
 public class FindCompatibleVersionTests
@@ -86,6 +89,39 @@ public class FindCompatibleVersionTests
         var result = releaseManager.FindCompatibleVersion("4.3", false, []);
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void FindCompatibleVersionResult_ValidProjectVersion_ReturnsSuccess()
+    {
+        var releaseManager = new ReleaseManagerBuilder().Build();
+
+        var result = releaseManager.FindCompatibleVersionResult("4.3", false, TestInstalledVersions);
+
+        var success = Assert.IsType<Result<string, CompatibilityError>.Success>(result);
+        Assert.Equal("4.3-stable-standard", success.Value);
+    }
+
+    [Fact]
+    public void FindCompatibleVersionResult_EmptyInstalledVersions_ReturnsNoInstalledVersions()
+    {
+        var releaseManager = new ReleaseManagerBuilder().Build();
+
+        var result = releaseManager.FindCompatibleVersionResult("4.3", false, []);
+
+        var failure = Assert.IsType<Result<string, CompatibilityError>.Failure>(result);
+        Assert.IsType<CompatibilityError.NoInstalledVersions>(failure.Error);
+    }
+
+    [Fact]
+    public void FindCompatibleVersionResult_NoMatch_ReturnsNotFound()
+    {
+        var releaseManager = new ReleaseManagerBuilder().Build();
+
+        var result = releaseManager.FindCompatibleVersionResult("9.9", false, TestInstalledVersions);
+
+        var failure = Assert.IsType<Result<string, CompatibilityError>.Failure>(result);
+        Assert.IsType<CompatibilityError.NotFound>(failure.Error);
     }
 
     [Theory]

--- a/Fgvm.Tests/Godot/ReleaseManager/QueryTests.cs
+++ b/Fgvm.Tests/Godot/ReleaseManager/QueryTests.cs
@@ -1,3 +1,4 @@
+using Fgvm.Godot;
 using Fgvm.Types;
 using Moq;
 
@@ -12,7 +13,7 @@ public class QueryTests
     public async Task SearchReleases_Query_ReturnsExpectedResults(string[] query, string[] expected)
     {
         var releaseManager = new ReleaseManagerBuilder().Build();
-        var result = await releaseManager.SearchRemoteReleases(query, CancellationToken.None);
+        var result = await releaseManager.SearchRemoteReleases(query, ReleaseFetchMode.UseCache, CancellationToken.None);
         Assert.IsType<Result<IEnumerable<string>, NetworkError>.Success>(result);
         var success = Assert.IsType<Result<IEnumerable<string>, NetworkError>.Success>(result);
         Assert.Equal(expected, success.Value);
@@ -117,7 +118,7 @@ public class QueryTests
             .WithReleases(new List<string>())
             .Build();
 
-        var result = await releaseManager.SearchRemoteReleases(["stable"], CancellationToken.None);
+        var result = await releaseManager.SearchRemoteReleases(["stable"], ReleaseFetchMode.UseCache, CancellationToken.None);
         Assert.IsType<Result<IEnumerable<string>, NetworkError>.Success>(result);
         var success = Assert.IsType<Result<IEnumerable<string>, NetworkError>.Success>(result);
         Assert.Empty(success.Value);
@@ -128,14 +129,14 @@ public class QueryTests
     {
         var cts = new CancellationTokenSource();
         var releaseManager = new ReleaseManagerBuilder()
-            .ConfigureDownloadClient(mock =>
+            .ConfigureReleaseCatalog(mock =>
             {
-                mock.Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
+                mock.Setup(x => x.ReadReleaseIds(It.IsAny<ReleaseFetchMode>(), It.IsAny<CancellationToken>()))
                     .ThrowsAsync(new OperationCanceledException());
             })
             .Build();
 
-        await Assert.ThrowsAsync<OperationCanceledException>(() => releaseManager.SearchRemoteReleases(["stable"], cts.Token));
+        await Assert.ThrowsAsync<OperationCanceledException>(() => releaseManager.SearchRemoteReleases(["stable"], ReleaseFetchMode.UseCache, cts.Token));
     }
 
     [Fact]
@@ -218,7 +219,7 @@ public class QueryTests
             .Build();
 
         // Test chronological ordering (for search/display)
-        var chronologicalResult = await releaseManager.SearchRemoteReleases(["4"], CancellationToken.None);
+        var chronologicalResult = await releaseManager.SearchRemoteReleases(["4"], ReleaseFetchMode.UseCache, CancellationToken.None);
         var success = Assert.IsType<Result<IEnumerable<string>, NetworkError>.Success>(chronologicalResult);
         var chronologicalArray = success.Value.ToArray();
 

--- a/Fgvm.Tests/Godot/ReleaseManager/ReleaseManagerBuilder.cs
+++ b/Fgvm.Tests/Godot/ReleaseManager/ReleaseManagerBuilder.cs
@@ -10,7 +10,9 @@ namespace Fgvm.Tests.Godot.ReleaseManager;
 public class ReleaseManagerBuilder
 {
     private readonly Mock<IDownloadClient> _mockDownloadClient;
+    private readonly Mock<IReleaseCatalog> _mockReleaseCatalog;
     private Action<Mock<IDownloadClient>>? _downloadClientConfig;
+    private Action<Mock<IReleaseCatalog>>? _releaseCatalogConfig;
     private IEnumerable<string> _releases;
     private SystemInfo _systemInfo;
 
@@ -18,12 +20,17 @@ public class ReleaseManagerBuilder
     {
         _systemInfo = new SystemInfo(OS.Windows, Architecture.X64);
         _mockDownloadClient = new Mock<IDownloadClient>();
+        _mockReleaseCatalog = new Mock<IReleaseCatalog>();
         _releases = TestData.TestReleases;
 
         _mockDownloadClient
             .Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<Result<IEnumerable<string>, NetworkError>>(
                 new Result<IEnumerable<string>, NetworkError>.Success(_releases)));
+        _mockReleaseCatalog
+            .Setup(x => x.ReadReleaseIds(It.IsAny<ReleaseFetchMode>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult<Result<string[], NetworkError>>(
+                new Result<string[], NetworkError>.Success(_releases.ToArray())));
     }
 
     public ReleaseManagerBuilder WithOSAndArch(OS os, Architecture arch)
@@ -39,6 +46,10 @@ public class ReleaseManagerBuilder
             .Setup(x => x.ListReleases(It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<Result<IEnumerable<string>, NetworkError>>(
                 new Result<IEnumerable<string>, NetworkError>.Success(_releases)));
+        _mockReleaseCatalog
+            .Setup(x => x.ReadReleaseIds(It.IsAny<ReleaseFetchMode>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.FromResult<Result<string[], NetworkError>>(
+                new Result<string[], NetworkError>.Success(_releases.ToArray())));
 
         return this;
     }
@@ -49,13 +60,21 @@ public class ReleaseManagerBuilder
         return this;
     }
 
+    public ReleaseManagerBuilder ConfigureReleaseCatalog(Action<Mock<IReleaseCatalog>> config)
+    {
+        _releaseCatalogConfig = config;
+        return this;
+    }
+
     public Fgvm.Godot.ReleaseManager Build()
     {
         _downloadClientConfig?.Invoke(_mockDownloadClient);
+        _releaseCatalogConfig?.Invoke(_mockReleaseCatalog);
 
         return new Fgvm.Godot.ReleaseManager(
             new HostSystem(_systemInfo, new Mock<IPathService>().Object, new Mock<ILogger<HostSystem>>().Object),
             new PlatformStringProvider(_systemInfo),
-            _mockDownloadClient.Object);
+            _mockDownloadClient.Object,
+            _mockReleaseCatalog.Object);
     }
 }

--- a/Fgvm.Tests/Godot/ReleaseManager/TryFindReleaseByQueryTests.cs
+++ b/Fgvm.Tests/Godot/ReleaseManager/TryFindReleaseByQueryTests.cs
@@ -1,4 +1,5 @@
 using Fgvm.Godot;
+using Fgvm.Types;
 
 namespace Fgvm.Tests.Godot.ReleaseManager;
 
@@ -140,5 +141,38 @@ public class TryFindReleaseByQueryTests
         Assert.NotNull(result);
         Assert.Equal(RuntimeEnvironment.Standard, result.RuntimeEnvironment);
         Assert.Equal("4.2-stable-standard", result.ReleaseNameWithRuntime);
+    }
+
+    [Fact]
+    public void ResolveReleaseQuery_ValidQuery_ReturnsSuccess()
+    {
+        var releaseManager = new ReleaseManagerBuilder().Build();
+
+        var result = releaseManager.ResolveReleaseQuery(["4.2-stable-standard"], TestReleases.ToArray());
+
+        var success = Assert.IsType<Result<Release, QueryError>.Success>(result);
+        Assert.Equal("4.2-stable-standard", success.Value.ReleaseNameWithRuntime);
+    }
+
+    [Fact]
+    public void ResolveReleaseQuery_InvalidQuery_ReturnsInvalidQueryFailure()
+    {
+        var releaseManager = new ReleaseManagerBuilder().Build();
+
+        var result = releaseManager.ResolveReleaseQuery(["4.5-bad"], TestReleases.ToArray());
+
+        var failure = Assert.IsType<Result<Release, QueryError>.Failure>(result);
+        Assert.IsType<QueryError.InvalidQuery>(failure.Error);
+    }
+
+    [Fact]
+    public void ResolveReleaseQuery_NoMatch_ReturnsNotFoundFailure()
+    {
+        var releaseManager = new ReleaseManagerBuilder().Build();
+
+        var result = releaseManager.ResolveReleaseQuery(["9.9"], TestReleases.ToArray());
+
+        var failure = Assert.IsType<Result<Release, QueryError>.Failure>(result);
+        Assert.IsType<QueryError.NotFound>(failure.Error);
     }
 }

--- a/Fgvm.Tests/Services/InstallationOrchestratorTests.cs
+++ b/Fgvm.Tests/Services/InstallationOrchestratorTests.cs
@@ -99,7 +99,7 @@ public sealed class InstallationOrchestratorTests : IDisposable
                     false,
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Result<InstallationOutcome, InstallationError>.Success(
-                new InstallationOutcome.NewInstallation(releaseName, new ChecksumVerification.Skipped())));
+                new InstallationOutcome.NewInstallation(releaseName, new ChecksumVerification.Verified())));
 
         var result = await _orchestrator.InstallAsync(query);
 
@@ -120,7 +120,7 @@ public sealed class InstallationOrchestratorTests : IDisposable
                     true,
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Result<InstallationOutcome, InstallationError>.Success(
-                new InstallationOutcome.NewInstallation("4.3.0-stable", new ChecksumVerification.Skipped())));
+                new InstallationOutcome.NewInstallation("4.3.0-stable", new ChecksumVerification.Verified())));
 
         var result = await _orchestrator.InstallAsync(query);
 
@@ -141,7 +141,7 @@ public sealed class InstallationOrchestratorTests : IDisposable
                     true,
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Result<InstallationOutcome, InstallationError>.Success(
-                new InstallationOutcome.NewInstallation("4.3.0-stable", new ChecksumVerification.Skipped())));
+                new InstallationOutcome.NewInstallation("4.3.0-stable", new ChecksumVerification.Verified())));
 
         var result = await _orchestrator.InstallAsync(query, setAsDefault: true);
 
@@ -150,10 +150,9 @@ public sealed class InstallationOrchestratorTests : IDisposable
     }
 
     [Fact]
-    public async Task InstallAsync_ChecksumAndSymlinkWarnings_RendersWarnings()
+    public async Task InstallAsync_SymlinkWarning_RendersWarning()
     {
         var query = new[] { "4.3.0" };
-        var checksum = new ChecksumVerification.Failed(new NetworkError.ConnectionFailure("offline"));
 
         _mockHostSystem.Setup(x => x.ListInstallations()).Returns(new[] { "4.2.0-stable" });
         _mockInstallationService.Setup(x =>
@@ -163,13 +162,35 @@ public sealed class InstallationOrchestratorTests : IDisposable
                     false,
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Result<InstallationOutcome, InstallationError>.Success(
-                new InstallationOutcome.NewInstallation("4.3.0-stable", checksum, new SymlinkError.PermissionDenied())));
+                new InstallationOutcome.NewInstallation("4.3.0-stable", new ChecksumVerification.Verified(),
+                    new SymlinkError.PermissionDenied())));
 
         var result = await _orchestrator.InstallAsync(query);
 
         Assert.IsType<Result<InstallationOutcome, InstallationError>.Success>(result);
-        Assert.Contains("Could not verify checksum", _console.Output);
         Assert.Contains("Unable to create symlinks due to insufficient permissions", _console.Output);
+    }
+
+    [Fact]
+    public async Task InstallAsync_UnavailableChecksum_RendersExplicitWarning()
+    {
+        var query = new[] { "3.2.1" };
+
+        _mockHostSystem.Setup(x => x.ListInstallations()).Returns(new[] { "4.2.0-stable" });
+        _mockInstallationService.Setup(x =>
+                x.InstallByQueryAsync(
+                    It.Is<string[]>(q => q.SequenceEqual(query)),
+                    It.IsAny<IProgress<OperationProgress<InstallationStage>>>(),
+                    false,
+                    It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<InstallationOutcome, InstallationError>.Success(
+                new InstallationOutcome.NewInstallation("3.2.1-stable-standard", new ChecksumVerification.Unavailable())));
+
+        var result = await _orchestrator.InstallAsync(query);
+
+        Assert.IsType<Result<InstallationOutcome, InstallationError>.Success>(result);
+        Assert.Contains("Checksum unavailable", _console.Output);
+        Assert.Contains("verification", _console.Output);
     }
 
     public void Dispose()

--- a/Fgvm.Tests/Services/InstallationOrchestratorTests.cs
+++ b/Fgvm.Tests/Services/InstallationOrchestratorTests.cs
@@ -32,7 +32,7 @@ public sealed class InstallationOrchestratorTests : IDisposable
         mockPathService.Setup(x => x.RootPath).Returns(_tempRoot);
         mockPathService.Setup(x => x.SymlinkPath).Returns(Path.Combine(_tempRoot, "bin", "godot"));
         mockPathService.Setup(x => x.ConfigPath).Returns(Path.Combine(_tempRoot, "fgvm.ini"));
-        mockPathService.Setup(x => x.ReleasesPath).Returns(Path.Combine(_tempRoot, ".releases"));
+        mockPathService.Setup(x => x.ReleasesPath).Returns(Path.Combine(_tempRoot, "releases.json"));
         mockPathService.Setup(x => x.BinPath).Returns(Path.Combine(_tempRoot, "bin"));
         mockPathService.Setup(x => x.MacAppSymlinkPath).Returns(Path.Combine(_tempRoot, "bin", "Godot.app"));
         mockPathService.Setup(x => x.LogPath).Returns(Path.Combine(_tempRoot, "fgvm.log"));

--- a/Fgvm.Tests/Services/InstallationServiceTests.cs
+++ b/Fgvm.Tests/Services/InstallationServiceTests.cs
@@ -1,9 +1,11 @@
 using Fgvm.Environment;
 using Fgvm.Godot;
+using Fgvm.Progress;
 using Fgvm.Services;
 using Fgvm.Types;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using System.IO.Compression;
 
 namespace Fgvm.Tests.Services;
 
@@ -41,14 +43,68 @@ public class InstallationServiceTests
         releaseCatalog.Verify(x => x.ReadReleaseIds(ReleaseFetchMode.ForceRemote, It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task InstallReleaseAsync_MissingCatalogArtifact_ContinuesWithUnavailableChecksum()
+    {
+        var rootPath = Path.Combine(Path.GetTempPath(), "fgvm-install-service-tests", Guid.NewGuid().ToString("N"));
+        var release = Release.TryParse("3.2.1-stable-standard")! with
+        {
+            OS = OS.MacOS,
+            PlatformString = "osx.64"
+        };
+
+        var releaseManager = new Mock<IReleaseManager>();
+        releaseManager.Setup(x => x.GetZipFile(It.IsAny<string>(), release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<HttpResponseMessage, NetworkError>.Success(new HttpResponseMessage
+            {
+                Content = new ByteArrayContent(CreateZipArchive())
+            }));
+
+        var releaseCatalog = new Mock<IReleaseCatalog>();
+        releaseCatalog.Setup(x => x.FindOrHydrateArtifact(release, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<ReleaseArtifact, NetworkError>.Success(new ReleaseArtifact(release.ZipFileName, null)));
+
+        var hostSystem = new Mock<IHostSystem>();
+        var pathService = new Mock<IPathService>();
+        pathService.SetupGet(x => x.RootPath).Returns(rootPath);
+        pathService.SetupGet(x => x.ReleasesPath).Returns(Path.Combine(rootPath, "releases.json"));
+
+        var service = new InstallationService(
+            hostSystem.Object,
+            releaseManager.Object,
+            releaseCatalog.Object,
+            pathService.Object,
+            NullLogger<InstallationService>.Instance);
+
+        try
+        {
+            var result = await service.InstallReleaseAsync(
+                release,
+                new Progress<OperationProgress<InstallationStage>>(),
+                setAsDefault: false,
+                CancellationToken.None);
+
+            var success = Assert.IsType<Result<InstallationOutcome, InstallationError>.Success>(result);
+            var installation = Assert.IsType<InstallationOutcome.NewInstallation>(success.Value);
+            Assert.IsType<ChecksumVerification.Unavailable>(installation.ChecksumStatus);
+        }
+        finally
+        {
+            if (Directory.Exists(rootPath))
+            {
+                Directory.Delete(rootPath, true);
+            }
+        }
+    }
+
     [Theory]
     [MemberData(nameof(ParseTestData))]
     public void ParseSha512SumsContent_ReturnsExpectedSha512SumsContent(string fileName, string hash)
     {
-        var result = InstallationService.ParseSha512SumsContent(fileName, ParseSha512SumsContentTestInput());
+        var artifacts = ReleaseCatalog.ParseSha512SumsContent(ParseSha512SumsContentTestInput());
 
-        var success = Assert.IsType<Result<string, InstallationError.ChecksumParseError>.Success>(result);
-        Assert.Equal(hash, success.Value);
+        var artifact = Assert.Single(artifacts, entry => entry.FileName == fileName);
+        Assert.Equal(hash, artifact.Sha512);
     }
 
     public static IEnumerable<object[]> ParseTestData()
@@ -264,5 +320,18 @@ public class InstallationServiceTests
         }
 
         return releaseManager;
+    }
+
+    private static byte[] CreateZipArchive()
+    {
+        using var stream = new MemoryStream();
+        using (var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = archive.CreateEntry("Godot");
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write("fake executable");
+        }
+
+        return stream.ToArray();
     }
 }

--- a/Fgvm.Tests/Services/InstallationServiceTests.cs
+++ b/Fgvm.Tests/Services/InstallationServiceTests.cs
@@ -1,17 +1,54 @@
+using Fgvm.Environment;
+using Fgvm.Godot;
 using Fgvm.Services;
+using Fgvm.Types;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
 
 namespace Fgvm.Tests.Services;
 
 public class InstallationServiceTests
 {
+    [Fact]
+    public async Task FetchReleaseNames_UsesCatalogCacheByDefault()
+    {
+        var releaseManager = CreateReleaseManagerMock("4.4-stable");
+        var releaseCatalog = new Mock<IReleaseCatalog>();
+        releaseCatalog.Setup(x => x.ReadReleaseIds(ReleaseFetchMode.UseCache, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<string[], NetworkError>.Success(["4.4-stable"]));
+
+        var service = CreateService(releaseManager.Object, releaseCatalog.Object);
+
+        var releaseNames = await service.FetchReleaseNames(CancellationToken.None);
+
+        Assert.Equal(["4.4-stable"], releaseNames);
+        releaseCatalog.Verify(x => x.ReadReleaseIds(ReleaseFetchMode.UseCache, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task FetchReleaseNames_ForceRemote_ForcesRemoteCatalogRefresh()
+    {
+        var releaseManager = CreateReleaseManagerMock("4.4-stable");
+        var releaseCatalog = new Mock<IReleaseCatalog>();
+        releaseCatalog.Setup(x => x.ReadReleaseIds(ReleaseFetchMode.ForceRemote, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<string[], NetworkError>.Success(["4.4-stable"]));
+
+        var service = CreateService(releaseManager.Object, releaseCatalog.Object);
+
+        var releaseNames = await service.FetchReleaseNames(CancellationToken.None, ReleaseFetchMode.ForceRemote);
+
+        Assert.Equal(["4.4-stable"], releaseNames);
+        releaseCatalog.Verify(x => x.ReadReleaseIds(ReleaseFetchMode.ForceRemote, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
     [Theory]
     [MemberData(nameof(ParseTestData))]
-    public void TryParseSha512SumsContent_ReturnsExpectedSha512SumsContent(string fileName, string hash)
+    public void ParseSha512SumsContent_ReturnsExpectedSha512SumsContent(string fileName, string hash)
     {
-        var parsed = InstallationService.TryParseSha512SumsContent(fileName, TryParseSha512SumsContentTestInput());
+        var result = InstallationService.ParseSha512SumsContent(fileName, ParseSha512SumsContentTestInput());
 
-        Assert.NotNull(parsed);
-        Assert.Equal(parsed, hash);
+        var success = Assert.IsType<Result<string, InstallationError.ChecksumParseError>.Success>(result);
+        Assert.Equal(hash, success.Value);
     }
 
     public static IEnumerable<object[]> ParseTestData()
@@ -172,7 +209,7 @@ public class InstallationServiceTests
         ];
     }
 
-    private static string TryParseSha512SumsContentTestInput() =>
+    private static string ParseSha512SumsContentTestInput() =>
         """
                        57557f3a05476518f2d9388dba4b2e9a5fd09a6ba7e5247b73919a7d31c846d5b0b2379279543c12cc7cd03ae828cf84751b1a0499d1ad2bb1f546c9372976e3  godot-4.4-dev3.tar.xz
                        b6e37f559e52417b6734f18d09f380bc26c0e755457b5d94890dd9515504170d639257876683bab78dde8e260a69e197655717dcbb951f413099fb06f8807e63  godot-4.4-dev3.tar.xz.sha256
@@ -201,4 +238,31 @@ public class InstallationServiceTests
                        ae3aaf0f92d4dac271940ee2a4817d004f91231a17429264fd806330e143036d30348fca09f46e0c92cda752819302941a7b48a4358cc12f436d90b13352a5b7  Godot_v4.4-dev3_mono_win64.zip
                        461b48ccff128969f8c7105b9a423569325692ad48af0ed838eff216cede765775f176206e21bd9e47bcd0aa0475bab58f3583c183c99db2f5a00cf563dcdea4  Godot_v4.4-dev3_mono_windows_arm64.zip
         """;
+
+    private static InstallationService CreateService(IReleaseManager releaseManager, IReleaseCatalog releaseCatalog)
+    {
+        var hostSystem = new Mock<IHostSystem>();
+        var pathService = new Mock<IPathService>();
+        pathService.SetupGet(x => x.ReleasesPath).Returns(Path.Combine(Path.GetTempPath(), "releases.json"));
+
+        return new InstallationService(
+            hostSystem.Object,
+            releaseManager,
+            releaseCatalog,
+            pathService.Object,
+            NullLogger<InstallationService>.Instance);
+    }
+
+    private static Mock<IReleaseManager> CreateReleaseManagerMock(params string[] releaseIds)
+    {
+        var releaseManager = new Mock<IReleaseManager>();
+
+        foreach (var releaseId in releaseIds)
+        {
+            releaseManager.Setup(x => x.TryCreateRelease($"{releaseId}-standard"))
+                .Returns(Release.TryParse($"{releaseId}-standard"));
+        }
+
+        return releaseManager;
+    }
 }

--- a/Fgvm.Tests/Services/VersionManagementServiceTests.cs
+++ b/Fgvm.Tests/Services/VersionManagementServiceTests.cs
@@ -36,7 +36,7 @@ public class VersionManagementServiceTests
         mockPathService.Setup(x => x.RootPath).Returns("/test/fgvm");
         mockPathService.Setup(x => x.SymlinkPath).Returns("/test/fgvm/bin/godot");
         mockPathService.Setup(x => x.ConfigPath).Returns("/test/fgvm/fgvm.ini");
-        mockPathService.Setup(x => x.ReleasesPath).Returns("/test/fgvm/.releases");
+        mockPathService.Setup(x => x.ReleasesPath).Returns("/test/fgvm/releases.json");
         mockPathService.Setup(x => x.BinPath).Returns("/test/fgvm/bin");
         mockPathService.Setup(x => x.MacAppSymlinkPath).Returns("/test/fgvm/bin/Godot.app");
         mockPathService.Setup(x => x.LogPath).Returns("/test/fgvm/.log");

--- a/Fgvm.Tests/Services/VersionManagementServiceTests.cs
+++ b/Fgvm.Tests/Services/VersionManagementServiceTests.cs
@@ -367,7 +367,7 @@ public class VersionManagementServiceTests
 
         var mockRelease = CreateMockRelease(newVersion);
         var installationResult = new Result<InstallationOutcome, InstallationError>.Success(
-            new InstallationOutcome.NewInstallation(mockRelease.ReleaseNameWithRuntime, new ChecksumVerification.Skipped()));
+            new InstallationOutcome.NewInstallation(mockRelease.ReleaseNameWithRuntime, new ChecksumVerification.Verified()));
 
         _mockInstallationService.Setup(x =>
                 x.InstallByQueryAsync(query, It.IsAny<IProgress<OperationProgress<InstallationStage>>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
@@ -456,7 +456,7 @@ public class VersionManagementServiceTests
 
         var mockRelease = CreateMockRelease(compatibleVersion);
         var installationResult = new Result<InstallationOutcome, InstallationError>.Success(
-            new InstallationOutcome.NewInstallation(mockRelease.ReleaseNameWithRuntime, new ChecksumVerification.Skipped()));
+            new InstallationOutcome.NewInstallation(mockRelease.ReleaseNameWithRuntime, new ChecksumVerification.Verified()));
 
         _mockInstallationService.Setup(x =>
                 x.InstallByQueryAsync(It.Is<string[]>(q => q.SequenceEqual(new[] { projectVersion })),
@@ -529,7 +529,7 @@ public class VersionManagementServiceTests
 
         var mockRelease = CreateMockRelease(compatibleVersion);
         var installationResult = new Result<InstallationOutcome, InstallationError>.Success(
-            new InstallationOutcome.NewInstallation(mockRelease.ReleaseNameWithRuntime, new ChecksumVerification.Skipped()));
+            new InstallationOutcome.NewInstallation(mockRelease.ReleaseNameWithRuntime, new ChecksumVerification.Verified()));
 
         _mockInstallationService.Setup(x =>
                 x.InstallByQueryAsync(It.Is<string[]>(q => q.SequenceEqual(new[] { projectVersion })),

--- a/Fgvm/Environment/PathService.cs
+++ b/Fgvm/Environment/PathService.cs
@@ -16,7 +16,7 @@ public interface IPathService
     string ConfigPath { get; }
 
     /// <summary>
-    ///     Path to the releases cache file.
+    ///     Path to the releases catalog file.
     /// </summary>
     string ReleasesPath { get; }
 
@@ -49,7 +49,7 @@ public sealed class PathService : IPathService
             ? Path.GetFullPath("fgvm", _fgvmHomeEnvVar)
             : Path.GetFullPath("fgvm", System.Environment.GetFolderPath(System.Environment.SpecialFolder.UserProfile));
     public string ConfigPath => Path.Combine(RootPath, "fgvm.ini");
-    public string ReleasesPath => Path.Combine(RootPath, ".releases");
+    public string ReleasesPath => Path.Combine(RootPath, "releases.json");
     public string BinPath => Path.Combine(RootPath, "bin");
     public string SymlinkPath => Path.Combine(BinPath, "godot");
     public string MacAppSymlinkPath => Path.Combine(BinPath, "Godot.app");

--- a/Fgvm/Fgvm.csproj
+++ b/Fgvm/Fgvm.csproj
@@ -12,10 +12,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.2"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.2"/>
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2"/>
-        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.2"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.7"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Ini" Version="10.0.7"/>
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.7"/>
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Fgvm/Godot/DownloadClient.cs
+++ b/Fgvm/Godot/DownloadClient.cs
@@ -1,4 +1,3 @@
-using Fgvm.Environment;
 using Fgvm.Types;
 using Microsoft.Extensions.Logging;
 using System.Text.Json.Serialization;
@@ -9,36 +8,17 @@ public interface IDownloadClient
 {
     Task<Result<IEnumerable<string>, NetworkError>> ListReleases(CancellationToken cancellationToken);
     Task<Result<string, NetworkError>> GetSha512(Release godotRelease, CancellationToken cancellationToken);
-    Task<HttpResponseMessage> GetZipFile(string filename, Release godotRelease, CancellationToken cancellationToken);
+    Task<Result<HttpResponseMessage, NetworkError>> GetZipFile(string filename, Release godotRelease, CancellationToken cancellationToken);
 }
 
 /// <summary>
 ///     A download client that coordinates between GitHub and TuxFamily sources.
 ///     Uses GitHub as primary and TuxFamily as backup for improved reliability.
 /// </summary>
-public class DownloadClient(IGitHubClient gitHubClient, ITuxFamilyClient tuxFamilyClient, IPathService pathService, ILogger<DownloadClient> logger) : IDownloadClient
+public class DownloadClient(IGitHubClient gitHubClient, ITuxFamilyClient tuxFamilyClient, ILogger<DownloadClient> logger) : IDownloadClient
 {
-    public async Task<Result<IEnumerable<string>, NetworkError>> ListReleases(CancellationToken cancellationToken)
-    {
-        var result = await gitHubClient.ListReleasesAsync(cancellationToken);
-
-        // Write cache on successful fetch
-        if (result is Result<IEnumerable<string>, NetworkError>.Success success)
-        {
-            var releaseArray = success.Value.ToArray();
-            try
-            {
-                await File.WriteAllLinesAsync(pathService.ReleasesPath, releaseArray, cancellationToken);
-                logger.LogInformation("Updated releases cache at {ReleasesPath} with {Count} releases", pathService.ReleasesPath, releaseArray.Length);
-            }
-            catch (Exception cacheEx)
-            {
-                logger.LogWarning("Failed to write releases cache, continuing anyway: {Message}", cacheEx.Message);
-            }
-        }
-
-        return result;
-    }
+    public async Task<Result<IEnumerable<string>, NetworkError>> ListReleases(CancellationToken cancellationToken) =>
+        await gitHubClient.ListReleasesAsync(cancellationToken);
 
     public async Task<Result<string, NetworkError>> GetSha512(Release godotRelease, CancellationToken cancellationToken)
     {
@@ -46,30 +26,32 @@ public class DownloadClient(IGitHubClient gitHubClient, ITuxFamilyClient tuxFami
 
         // Try GitHub first
         var gitHubResult = await gitHubClient.GetSha512Async(godotRelease, cancellationToken);
-        if (gitHubResult is Result<string, NetworkError>.Success gitHubSuccess)
+        switch (gitHubResult)
         {
-            logger.LogInformation("Found SHA512 for {Version} at GitHub", godotRelease.Version);
-            return gitHubSuccess;
-        }
-
-        if (gitHubResult is Result<string, NetworkError>.Failure gitHubFailure)
-        {
-            logger.LogError("GitHub SHA512 failed for {Version}", godotRelease.Version);
-            errors.Add(gitHubFailure.Error);
+            case Result<string, NetworkError>.Success gitHubSuccess:
+                logger.LogInformation("Found SHA512 for {Version} at GitHub", godotRelease.Version);
+                return gitHubSuccess;
+            case Result<string, NetworkError>.Failure gitHubFailure:
+                logger.LogError("GitHub SHA512 failed for {Version}", godotRelease.Version);
+                errors.Add(gitHubFailure.Error);
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected Result type");
         }
 
         // Fallback to TuxFamily
         var tuxFamilyResult = await tuxFamilyClient.GetSha512Async(godotRelease, cancellationToken);
-        if (tuxFamilyResult is Result<string, NetworkError>.Success tuxFamilySuccess)
+        switch (tuxFamilyResult)
         {
-            logger.LogInformation("Found SHA512 for {Version} at TuxFamily", godotRelease.Version);
-            return tuxFamilySuccess;
-        }
-
-        if (tuxFamilyResult is Result<string, NetworkError>.Failure tuxFamilyFailure)
-        {
-            logger.LogError("TuxFamily SHA512 failed for {Version}", godotRelease.Version);
-            errors.Add(tuxFamilyFailure.Error);
+            case Result<string, NetworkError>.Success tuxFamilySuccess:
+                logger.LogInformation("Found SHA512 for {Version} at TuxFamily", godotRelease.Version);
+                return tuxFamilySuccess;
+            case Result<string, NetworkError>.Failure tuxFamilyFailure:
+                logger.LogError("TuxFamily SHA512 failed for {Version}", godotRelease.Version);
+                errors.Add(tuxFamilyFailure.Error);
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected Result type");
         }
 
         logger.LogError("SHA512-SUMS.txt unavailable from all sources for {Version}", godotRelease.Version);
@@ -77,35 +59,43 @@ public class DownloadClient(IGitHubClient gitHubClient, ITuxFamilyClient tuxFami
             new NetworkError.AllSourcesFailed("SHA512-SUMS.txt", errors));
     }
 
-    // TODO: Replace with Task<Result<HttpResponseMessage, NetworkError>> GetZipFile(string filename, Release godotRelease, CancellationToken cancellationToken)
-    public async Task<HttpResponseMessage> GetZipFile(string filename, Release godotRelease, CancellationToken cancellationToken)
+    public async Task<Result<HttpResponseMessage, NetworkError>> GetZipFile(string filename, Release godotRelease, CancellationToken cancellationToken)
     {
+        var errors = new List<NetworkError>();
+
         // Try GitHub first
-        try
+        var gitHubResult = await gitHubClient.GetZipFileAsync(filename, godotRelease, cancellationToken);
+        switch (gitHubResult)
         {
-            var response = await gitHubClient.GetZipFileAsync(filename, godotRelease, cancellationToken);
-            logger.LogInformation("Found {ReleaseNameWithRuntime} at GitHub", godotRelease.ReleaseNameWithRuntime);
-            return response;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError("GitHub zip file failed for {ReleaseNameWithRuntime}: {Message}", godotRelease.ReleaseNameWithRuntime, ex.Message);
+            case Result<HttpResponseMessage, NetworkError>.Success gitHubSuccess:
+                logger.LogInformation("Found {ReleaseNameWithRuntime} at GitHub", godotRelease.ReleaseNameWithRuntime);
+                return gitHubSuccess;
+            case Result<HttpResponseMessage, NetworkError>.Failure gitHubFailure:
+                logger.LogError("GitHub zip file failed for {ReleaseNameWithRuntime}", godotRelease.ReleaseNameWithRuntime);
+                errors.Add(gitHubFailure.Error);
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected Result type");
         }
 
         // Fallback to TuxFamily
-        try
+        var tuxFamilyResult = await tuxFamilyClient.GetZipFileAsync(filename, godotRelease, cancellationToken);
+        switch (tuxFamilyResult)
         {
-            var response = await tuxFamilyClient.GetZipFileAsync(filename, godotRelease, cancellationToken);
-            logger.LogInformation("Found {ReleaseNameWithRuntime} at TuxFamily", godotRelease.ReleaseNameWithRuntime);
-            return response;
-        }
-        catch (Exception ex)
-        {
-            logger.LogError("TuxFamily zip file failed for {ReleaseNameWithRuntime}: {Message}", godotRelease.ReleaseNameWithRuntime, ex.Message);
+            case Result<HttpResponseMessage, NetworkError>.Success tuxFamilySuccess:
+                logger.LogInformation("Found {ReleaseNameWithRuntime} at TuxFamily", godotRelease.ReleaseNameWithRuntime);
+                return tuxFamilySuccess;
+            case Result<HttpResponseMessage, NetworkError>.Failure tuxFamilyFailure:
+                logger.LogError("TuxFamily zip file failed for {ReleaseNameWithRuntime}", godotRelease.ReleaseNameWithRuntime);
+                errors.Add(tuxFamilyFailure.Error);
+                break;
+            default:
+                throw new InvalidOperationException("Unexpected Result type");
         }
 
         logger.LogError("{Filename} was missing from all sources for {ReleaseNameWithRuntime}", filename, godotRelease.ReleaseNameWithRuntime);
-        throw new HttpRequestException($"Wasn't able to download {filename} from any sources.");
+        return new Result<HttpResponseMessage, NetworkError>.Failure(
+            new NetworkError.AllSourcesFailed(filename, errors));
     }
 }
 

--- a/Fgvm/Godot/DownloadClient.cs
+++ b/Fgvm/Godot/DownloadClient.cs
@@ -7,6 +7,7 @@ namespace Fgvm.Godot;
 public interface IDownloadClient
 {
     Task<Result<IEnumerable<string>, NetworkError>> ListReleases(CancellationToken cancellationToken);
+    Task<Result<GodotReleaseManifest, NetworkError>> GetReleaseManifest(Release godotRelease, CancellationToken cancellationToken);
     Task<Result<string, NetworkError>> GetSha512(Release godotRelease, CancellationToken cancellationToken);
     Task<Result<HttpResponseMessage, NetworkError>> GetZipFile(string filename, Release godotRelease, CancellationToken cancellationToken);
 }
@@ -19,6 +20,9 @@ public class DownloadClient(IGitHubClient gitHubClient, ITuxFamilyClient tuxFami
 {
     public async Task<Result<IEnumerable<string>, NetworkError>> ListReleases(CancellationToken cancellationToken) =>
         await gitHubClient.ListReleasesAsync(cancellationToken);
+
+    public async Task<Result<GodotReleaseManifest, NetworkError>> GetReleaseManifest(Release godotRelease, CancellationToken cancellationToken) =>
+        await gitHubClient.GetReleaseManifestAsync(godotRelease.ReleaseName, cancellationToken);
 
     public async Task<Result<string, NetworkError>> GetSha512(Release godotRelease, CancellationToken cancellationToken)
     {
@@ -114,4 +118,5 @@ public class GitHubReleaseAsset
 [JsonSourceGenerationOptions(WriteIndented = true, PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(GitHubReleaseAsset))]
 [JsonSerializable(typeof(List<GitHubReleaseAsset>))]
+[JsonSerializable(typeof(GodotReleaseManifest))]
 internal partial class GithubReleaseAssetContext : JsonSerializerContext;

--- a/Fgvm/Godot/GitHubClient.cs
+++ b/Fgvm/Godot/GitHubClient.cs
@@ -9,6 +9,7 @@ namespace Fgvm.Godot;
 public interface IGitHubClient
 {
     Task<Result<IEnumerable<string>, NetworkError>> ListReleasesAsync(CancellationToken cancellationToken);
+    Task<Result<GodotReleaseManifest, NetworkError>> GetReleaseManifestAsync(string releaseName, CancellationToken cancellationToken);
     Task<Result<string, NetworkError>> GetSha512Async(Release godotRelease, CancellationToken cancellationToken);
     Task<Result<HttpResponseMessage, NetworkError>> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken);
 }
@@ -17,6 +18,7 @@ public class GitHubClient : IGitHubClient
 {
     private const string BaseUrl = "https://github.com/godotengine/godot-builds/releases/download";
     private const string ApiUrl = "https://api.github.com/repos/godotengine/godot-builds/contents/releases";
+    private const string RawManifestBaseUrl = "https://raw.githubusercontent.com/godotengine/godot-builds/main/releases";
     private readonly Lazy<IConfiguration> _configuration;
 
     private readonly HttpClient _httpClient;
@@ -56,10 +58,51 @@ public class GitHubClient : IGitHubClient
             return new Result<IEnumerable<string>, NetworkError>.Failure(
                 new NetworkError.RequestFailure(ApiUrl, (int)response.StatusCode, body));
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError("Failed to list releases from GitHub: {Message}", ex.Message);
             return new Result<IEnumerable<string>, NetworkError>.Failure(
+                new NetworkError.ConnectionFailure(ex.Message));
+        }
+    }
+
+    public async Task<Result<GodotReleaseManifest, NetworkError>> GetReleaseManifestAsync(string releaseName, CancellationToken cancellationToken)
+    {
+        var url = $"{RawManifestBaseUrl}/godot-{releaseName}.json";
+
+        try
+        {
+            _logger.LogInformation("HTTP GET {Url}", url);
+            var response = await _httpClient.GetAsync(url, cancellationToken);
+            _logger.LogInformation("HTTP GET {Url} completed with status {StatusCode}", url, (int)response.StatusCode);
+
+            if (response.IsSuccessStatusCode)
+            {
+                var jsonString = await response.Content.ReadAsStringAsync(cancellationToken);
+                var manifest = JsonSerializer.Deserialize(jsonString, GithubReleaseAssetContext.Default.GodotReleaseManifest);
+                return manifest is not null
+                    ? new Result<GodotReleaseManifest, NetworkError>.Success(manifest)
+                    : new Result<GodotReleaseManifest, NetworkError>.Failure(
+                        new NetworkError.ConnectionFailure($"Release manifest {releaseName} was empty or invalid"));
+            }
+
+            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            _logger.LogError("{Url} returned {StatusCode}. Body: {Body}", url, response.StatusCode, body);
+            return new Result<GodotReleaseManifest, NetworkError>.Failure(
+                new NetworkError.RequestFailure(url, (int)response.StatusCode, body));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError("Failed to get release manifest from GitHub for {ReleaseName}: {Message}", releaseName, ex.Message);
+            return new Result<GodotReleaseManifest, NetworkError>.Failure(
                 new NetworkError.ConnectionFailure(ex.Message));
         }
     }
@@ -84,6 +127,10 @@ public class GitHubClient : IGitHubClient
             _logger.LogError("{Url} returned {StatusCode}. Body: {Body}", url, response.StatusCode, body);
             return new Result<string, NetworkError>.Failure(
                 new NetworkError.RequestFailure(url, (int)response.StatusCode, body));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/Fgvm/Godot/GitHubClient.cs
+++ b/Fgvm/Godot/GitHubClient.cs
@@ -10,7 +10,7 @@ public interface IGitHubClient
 {
     Task<Result<IEnumerable<string>, NetworkError>> ListReleasesAsync(CancellationToken cancellationToken);
     Task<Result<string, NetworkError>> GetSha512Async(Release godotRelease, CancellationToken cancellationToken);
-    Task<HttpResponseMessage> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken);
+    Task<Result<HttpResponseMessage, NetworkError>> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken);
 }
 
 public class GitHubClient : IGitHubClient
@@ -93,8 +93,7 @@ public class GitHubClient : IGitHubClient
         }
     }
 
-    // TODO: Replace with Task<Result<HttpResponseMessage, NetworkError>> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken)
-    public async Task<HttpResponseMessage> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken)
+    public async Task<Result<HttpResponseMessage, NetworkError>> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken)
     {
         var url = $"{BaseUrl}/{godotRelease.ReleaseName}/{filename}";
 
@@ -106,17 +105,23 @@ public class GitHubClient : IGitHubClient
 
             if (response.IsSuccessStatusCode)
             {
-                return response;
+                return new Result<HttpResponseMessage, NetworkError>.Success(response);
             }
 
             var body = await response.Content.ReadAsStringAsync(cancellationToken);
             _logger.LogError("{Url} returned {StatusCode}. Body: {Body}", url, response.StatusCode, body);
-            throw new HttpRequestException($"GitHub zip file request failed: {response.StatusCode}");
+            return new Result<HttpResponseMessage, NetworkError>.Failure(
+                new NetworkError.RequestFailure(url, (int)response.StatusCode, body));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             _logger.LogError("Failed to get zip file from GitHub for {ReleaseNameWithRuntime}: {Message}", godotRelease.ReleaseNameWithRuntime, ex.Message);
-            throw;
+            return new Result<HttpResponseMessage, NetworkError>.Failure(
+                new NetworkError.ConnectionFailure(ex.Message));
         }
     }
 

--- a/Fgvm/Godot/GodotReleaseManifest.cs
+++ b/Fgvm/Godot/GodotReleaseManifest.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace Fgvm.Godot;
+
+public sealed class GodotReleaseManifest
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("version")]
+    public required string Version { get; init; }
+
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+
+    [JsonPropertyName("release_date")]
+    public long? ReleaseDate { get; init; }
+
+    [JsonPropertyName("git_reference")]
+    public string? GitReference { get; init; }
+
+    [JsonPropertyName("files")]
+    public List<GodotReleaseManifestFile> Files { get; init; } = [];
+}
+
+public sealed class GodotReleaseManifestFile
+{
+    [JsonPropertyName("filename")]
+    public required string FileName { get; init; }
+
+    [JsonPropertyName("checksum")]
+    public required string Checksum { get; init; }
+}

--- a/Fgvm/Godot/ReleaseArtifact.cs
+++ b/Fgvm/Godot/ReleaseArtifact.cs
@@ -1,0 +1,6 @@
+namespace Fgvm.Godot;
+
+/// <summary>
+///     Artifact selected for installation. Sha512 is null when upstream metadata does not provide a checksum.
+/// </summary>
+public sealed record ReleaseArtifact(string FileName, string? Sha512);

--- a/Fgvm/Godot/ReleaseCatalog.cs
+++ b/Fgvm/Godot/ReleaseCatalog.cs
@@ -1,0 +1,268 @@
+using Fgvm.Environment;
+using Fgvm.Types;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Fgvm.Godot;
+
+public enum ReleaseFetchMode
+{
+    UseCache,
+    ForceRemote
+}
+
+/// <summary>
+///     Reads and updates the local releases catalog used to resolve searchable releases and artifact metadata.
+/// </summary>
+public interface IReleaseCatalog
+{
+    Task<Result<string[], NetworkError>> ReadReleaseIds(ReleaseFetchMode fetchMode, CancellationToken cancellationToken);
+    Task<ReleaseCatalogArtifact?> FindArtifact(Release release, CancellationToken cancellationToken);
+    Task RecordArtifact(Release release, string fileName, string sha512, CancellationToken cancellationToken);
+}
+
+public sealed class ReleaseCatalog(
+    IDownloadClient downloadClient,
+    IPathService pathService,
+    ILogger<ReleaseCatalog> logger) : IReleaseCatalog
+{
+    private static readonly TimeSpan CacheTtl = TimeSpan.FromDays(1);
+
+    public async Task<Result<string[], NetworkError>> ReadReleaseIds(ReleaseFetchMode fetchMode, CancellationToken cancellationToken)
+    {
+        if (fetchMode == ReleaseFetchMode.UseCache && IsCacheFresh())
+        {
+            var cached = await ReadCachedReleaseIds(cancellationToken);
+            if (cached.Length > 0)
+            {
+                return new Result<string[], NetworkError>.Success(cached);
+            }
+        }
+
+        var remote = await downloadClient.ListReleases(cancellationToken);
+        return remote switch
+        {
+            Result<IEnumerable<string>, NetworkError>.Success success => await RefreshCache(success.Value, cancellationToken),
+            Result<IEnumerable<string>, NetworkError>.Failure failure => new Result<string[], NetworkError>.Failure(failure.Error),
+            _ => throw new InvalidOperationException("Unexpected Result type")
+        };
+    }
+
+    public async Task<ReleaseCatalogArtifact?> FindArtifact(Release release, CancellationToken cancellationToken)
+    {
+        var manifest = await TryReadManifest(cancellationToken);
+        if (manifest is null)
+        {
+            return null;
+        }
+
+        var targetId = GetCatalogTargetId(release);
+        var runtimeId = release.RuntimeEnvironment.Name();
+
+        var releaseTypeId = GetReleaseTypeId(release);
+        return manifest.TryGetValue(release.Version, out var version) &&
+               version.TryGetValue(releaseTypeId, out var catalogRelease) &&
+               catalogRelease.TryGetValue(targetId, out var target) &&
+               target.TryGetValue(runtimeId, out var artifact)
+            ? artifact
+            : null;
+    }
+
+    public async Task RecordArtifact(Release release, string fileName, string sha512, CancellationToken cancellationToken)
+    {
+        var manifest = await TryReadManifest(cancellationToken) ?? [];
+        var targetId = GetCatalogTargetId(release);
+        var runtimeId = release.RuntimeEnvironment.Name();
+
+        var releaseTypeId = GetReleaseTypeId(release);
+
+        if (!manifest.TryGetValue(release.Version, out var version))
+        {
+            version = [];
+            manifest[release.Version] = version;
+        }
+
+        if (!version.TryGetValue(releaseTypeId, out var catalogRelease))
+        {
+            catalogRelease = [];
+            version[releaseTypeId] = catalogRelease;
+        }
+
+        if (!catalogRelease.TryGetValue(targetId, out var target))
+        {
+            target = [];
+            catalogRelease[targetId] = target;
+        }
+
+        target[runtimeId] = new ReleaseCatalogArtifact
+        {
+            FileName = fileName,
+            Sha512 = sha512
+        };
+
+        await WriteCacheBestEffort(manifest, cancellationToken);
+    }
+
+    private bool IsCacheFresh()
+    {
+        try
+        {
+            var file = new FileInfo(pathService.ReleasesPath);
+            return file.Exists && DateTimeOffset.UtcNow - file.LastWriteTimeUtc <= CacheTtl;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            logger.LogWarning(ex, "Failed to inspect release catalog at {ReleasesPath}; refreshing from remote", pathService.ReleasesPath);
+            return false;
+        }
+    }
+
+    private async Task<string[]> ReadCachedReleaseIds(CancellationToken cancellationToken)
+    {
+        var manifest = await TryReadManifest(cancellationToken);
+        if (manifest is null)
+        {
+            return [];
+        }
+
+        return SortReleaseIds(GetReleaseIds(manifest));
+    }
+
+    private async Task<ReleaseCatalogManifest?> TryReadManifest(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(pathService.ReleasesPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            await using var stream = File.OpenRead(pathService.ReleasesPath);
+            return await JsonSerializer.DeserializeAsync(stream, ReleaseCatalogJsonContext.Default.ReleaseCatalogManifest, cancellationToken);
+        }
+        catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+        {
+            logger.LogWarning(ex, "Failed to read release catalog at {ReleasesPath}; refreshing from remote", pathService.ReleasesPath);
+            return null;
+        }
+    }
+
+    private async Task WriteCacheBestEffort(ReleaseCatalogManifest manifest, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(pathService.ReleasesPath)!);
+            await using var stream = File.Create(pathService.ReleasesPath);
+            await JsonSerializer.SerializeAsync(stream, manifest, ReleaseCatalogJsonContext.Default.ReleaseCatalogManifest, cancellationToken);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.LogWarning(ex, "Failed to write release catalog at {ReleasesPath}; continuing with remote release ids", pathService.ReleasesPath);
+        }
+    }
+
+    private async Task<Result<string[], NetworkError>> RefreshCache(IEnumerable<string> remoteReleaseIds, CancellationToken cancellationToken)
+    {
+        var existing = await TryReadManifest(cancellationToken);
+        var manifest = CreateManifest(remoteReleaseIds, existing);
+        var releaseIds = SortReleaseIds(GetReleaseIds(manifest));
+
+        await WriteCacheBestEffort(manifest, cancellationToken);
+
+        return new Result<string[], NetworkError>.Success(releaseIds);
+    }
+
+    private static ReleaseCatalogManifest CreateManifest(IEnumerable<string> releaseIds, ReleaseCatalogManifest? existing)
+    {
+        var manifest = new ReleaseCatalogManifest();
+
+        foreach (var release in SortReleaseIds(releaseIds)
+                     .Select(Release.TryParse)
+                     .OfType<Release>())
+        {
+            var releaseTypeId = GetReleaseTypeId(release);
+
+            if (!manifest.TryGetValue(release.Version, out var version))
+            {
+                version = [];
+                manifest[release.Version] = version;
+            }
+
+            version[releaseTypeId] = existing is not null &&
+                                     existing.TryGetValue(release.Version, out var existingVersion) &&
+                                     existingVersion.TryGetValue(releaseTypeId, out var catalogRelease)
+                ? catalogRelease
+                : [];
+        }
+
+        return manifest;
+    }
+
+    private static IEnumerable<string> GetReleaseIds(ReleaseCatalogManifest manifest) =>
+        manifest.SelectMany(version => version.Value.Keys.Select(releaseTypeId => $"{version.Key}-{releaseTypeId}"));
+
+    private static string[] SortReleaseIds(IEnumerable<string> releaseIds) =>
+        releaseIds
+            .Select(Release.TryParse)
+            .OfType<Release>()
+            .OrderByDescending(release => release)
+            .Select(release => release.ReleaseName)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static string GetReleaseTypeId(Release release) =>
+        release.Type?.ToString() ?? "unknown";
+
+    private static string GetCatalogTargetId(Release release) =>
+        release.PlatformString switch
+        {
+            null => "unknown",
+            "mono_macos.universal" => "macos.universal",
+            "mono_osx.universal" => "osx.universal",
+            "mono_osx.64" or "mono_osx64" => "osx.64",
+            "mono_linux_x86_64" => "linux.x86_64",
+            "mono_linux_x86_32" => "linux.x86_32",
+            "mono_linux_arm32" => "linux.arm32",
+            "mono_linux_arm64" => "linux.arm64",
+            "mono_x11_64" => "x11.64",
+            "mono_x11_32" => "x11.32",
+            "mono_windows_arm64" => "windows_arm64",
+            "mono_win64" => "win64",
+            "mono_win32" => "win32",
+            var target when target.EndsWith(".exe", StringComparison.Ordinal) => target[..^4],
+            var target => target
+        };
+}
+
+/// <summary>
+///     Version -> release type -> target/platform -> runtime -> artifact.
+/// </summary>
+public sealed class ReleaseCatalogManifest : Dictionary<string, ReleaseCatalogVersion>
+{
+}
+
+public sealed class ReleaseCatalogVersion : Dictionary<string, ReleaseCatalogRelease>
+{
+}
+
+public sealed class ReleaseCatalogRelease : Dictionary<string, ReleaseCatalogTarget>
+{
+}
+
+public sealed class ReleaseCatalogTarget : Dictionary<string, ReleaseCatalogArtifact>
+{
+}
+
+public sealed class ReleaseCatalogArtifact
+{
+    [JsonPropertyName("filename")]
+    public required string FileName { get; init; }
+
+    [JsonPropertyName("sha512")]
+    public required string Sha512 { get; init; }
+}
+
+[JsonSourceGenerationOptions(WriteIndented = true)]
+[JsonSerializable(typeof(ReleaseCatalogManifest))]
+internal partial class ReleaseCatalogJsonContext : JsonSerializerContext;

--- a/Fgvm/Godot/ReleaseCatalog.cs
+++ b/Fgvm/Godot/ReleaseCatalog.cs
@@ -12,14 +12,20 @@ public enum ReleaseFetchMode
     ForceRemote
 }
 
+internal abstract record ReleaseCatalogRead
+{
+    public sealed record Found(ReleaseCatalogManifest Manifest) : ReleaseCatalogRead;
+
+    public sealed record MissingOrInvalid : ReleaseCatalogRead;
+}
+
 /// <summary>
 ///     Reads and updates the local releases catalog used to resolve searchable releases and artifact metadata.
 /// </summary>
 public interface IReleaseCatalog
 {
     Task<Result<string[], NetworkError>> ReadReleaseIds(ReleaseFetchMode fetchMode, CancellationToken cancellationToken);
-    Task<ReleaseCatalogArtifact?> FindArtifact(Release release, CancellationToken cancellationToken);
-    Task RecordArtifact(Release release, string fileName, string sha512, CancellationToken cancellationToken);
+    Task<Result<ReleaseArtifact, NetworkError>> FindOrHydrateArtifact(Release release, CancellationToken cancellationToken);
 }
 
 public sealed class ReleaseCatalog(
@@ -31,146 +37,281 @@ public sealed class ReleaseCatalog(
 
     public async Task<Result<string[], NetworkError>> ReadReleaseIds(ReleaseFetchMode fetchMode, CancellationToken cancellationToken)
     {
-        if (fetchMode == ReleaseFetchMode.UseCache && IsCacheFresh())
+        var cachedResult = await ReadCatalogState(cancellationToken);
+
+        switch (cachedResult)
         {
-            var cached = await ReadCachedReleaseIds(cancellationToken);
-            if (cached.Length > 0)
-            {
-                return new Result<string[], NetworkError>.Success(cached);
-            }
+            case Result<ReleaseCatalogRead, NetworkError>.Failure failure:
+                return new Result<string[], NetworkError>.Failure(failure.Error);
+
+            case Result<ReleaseCatalogRead, NetworkError>.Success { Value: ReleaseCatalogRead.Found(var manifest) }
+                when fetchMode == ReleaseFetchMode.UseCache && IsReleaseIndexFresh(manifest) && GetReleaseIds(manifest).Any():
+                return new Result<string[], NetworkError>.Success(SortReleaseIds(GetReleaseIds(manifest)));
+
+            case Result<ReleaseCatalogRead, NetworkError>.Success success:
+                var refreshResult = await RefreshCatalog(GetExistingManifest(success.Value), cancellationToken);
+                return refreshResult switch
+                {
+                    Result<ReleaseCatalogManifest, NetworkError>.Success refreshed =>
+                        new Result<string[], NetworkError>.Success(SortReleaseIds(GetReleaseIds(refreshed.Value))),
+                    Result<ReleaseCatalogManifest, NetworkError>.Failure failure =>
+                        new Result<string[], NetworkError>.Failure(failure.Error),
+                    _ => throw new InvalidOperationException("Unexpected Result type")
+                };
+
+            default:
+                throw new InvalidOperationException("Unexpected Result type");
+        }
+    }
+
+    public async Task<Result<ReleaseArtifact, NetworkError>> FindOrHydrateArtifact(Release release, CancellationToken cancellationToken)
+    {
+        var manifestResult = await ReadCatalogOrRebuild(cancellationToken);
+        if (manifestResult is Result<ReleaseCatalogManifest, NetworkError>.Failure catalogFailure)
+        {
+            return new Result<ReleaseArtifact, NetworkError>.Failure(catalogFailure.Error);
         }
 
-        var remote = await downloadClient.ListReleases(cancellationToken);
-        return remote switch
+        if (manifestResult is not Result<ReleaseCatalogManifest, NetworkError>.Success catalogSuccess)
         {
-            Result<IEnumerable<string>, NetworkError>.Success success => await RefreshCache(success.Value, cancellationToken),
-            Result<IEnumerable<string>, NetworkError>.Failure failure => new Result<string[], NetworkError>.Failure(failure.Error),
+            throw new InvalidOperationException("Unexpected Result type");
+        }
+
+        var manifest = catalogSuccess.Value;
+
+        if (FindArtifact(manifest, release) is { } cached)
+        {
+            return new Result<ReleaseArtifact, NetworkError>.Success(cached);
+        }
+
+        var remoteManifestResult = await downloadClient.GetReleaseManifest(release, cancellationToken);
+        switch (remoteManifestResult)
+        {
+            case Result<GodotReleaseManifest, NetworkError>.Success success when success.Value.Files.Count > 0:
+                var recordResult = await RecordReleaseManifest(manifest, success.Value, release, cancellationToken);
+                return recordResult switch
+                {
+                    Result<ReleaseCatalogManifest, NetworkError>.Success recorded =>
+                        FindArtifact(recorded.Value, release) is { } artifact
+                            ? new Result<ReleaseArtifact, NetworkError>.Success(artifact)
+                            : new Result<ReleaseArtifact, NetworkError>.Failure(new NetworkError.ConnectionFailure(
+                                $"No artifact found for {release.ReleaseNameWithRuntime} on target {GetCatalogTargetId(release)}")),
+                    Result<ReleaseCatalogManifest, NetworkError>.Failure failure =>
+                        new Result<ReleaseArtifact, NetworkError>.Failure(failure.Error),
+                    _ => throw new InvalidOperationException("Unexpected Result type")
+                };
+
+            case Result<GodotReleaseManifest, NetworkError>.Success:
+                return await HydrateFromSha512Sums(manifest, release, cancellationToken);
+
+            case Result<GodotReleaseManifest, NetworkError>.Failure failure:
+                return new Result<ReleaseArtifact, NetworkError>.Failure(failure.Error);
+
+            default:
+                throw new InvalidOperationException("Unexpected Result type");
+        }
+    }
+
+    private async Task<Result<ReleaseArtifact, NetworkError>> HydrateFromSha512Sums(
+        ReleaseCatalogManifest manifest,
+        Release release,
+        CancellationToken cancellationToken)
+    {
+        var shaResult = await downloadClient.GetSha512(release, cancellationToken);
+        switch (shaResult)
+        {
+            case Result<string, NetworkError>.Success success:
+                var recordResult = await RecordArtifacts(manifest, release, ParseSha512SumsContent(success.Value), cancellationToken);
+                return recordResult switch
+                {
+                    Result<ReleaseCatalogManifest, NetworkError>.Success recorded =>
+                        new Result<ReleaseArtifact, NetworkError>.Success(
+                            FindArtifact(recorded.Value, release) ?? new ReleaseArtifact(release.ZipFileName, null)),
+                    Result<ReleaseCatalogManifest, NetworkError>.Failure failure =>
+                        new Result<ReleaseArtifact, NetworkError>.Failure(failure.Error),
+                    _ => throw new InvalidOperationException("Unexpected Result type")
+                };
+
+            case Result<string, NetworkError>.Failure failure:
+                logger.LogWarning(
+                    "Failed to hydrate {ReleaseName} from SHA512-SUMS.txt: {Error}. Continuing without catalog artifact metadata",
+                    release.ReleaseName,
+                    failure.Error);
+
+                return new Result<ReleaseArtifact, NetworkError>.Success(new ReleaseArtifact(release.ZipFileName, null));
+
+            default:
+                throw new InvalidOperationException("Unexpected Result type");
+        }
+    }
+
+    private async Task<Result<ReleaseCatalogManifest, NetworkError>> RecordReleaseManifest(
+        ReleaseCatalogManifest manifest,
+        GodotReleaseManifest godotManifest,
+        Release fallbackRelease,
+        CancellationToken cancellationToken)
+    {
+        var release = Release.TryParse(godotManifest.Name) ?? fallbackRelease;
+        return await RecordArtifacts(
+            manifest,
+            release,
+            godotManifest.Files.Select(file => new ReleaseCatalogArtifactEntry(file.FileName, file.Checksum)),
+            cancellationToken,
+            godotManifest.ReleaseDate,
+            godotManifest.GitReference);
+    }
+
+    private async Task<Result<ReleaseCatalogManifest, NetworkError>> RecordArtifacts(
+        ReleaseCatalogManifest manifest,
+        Release release,
+        IEnumerable<ReleaseCatalogArtifactEntry> artifacts,
+        CancellationToken cancellationToken,
+        long? releaseDate = null,
+        string? gitReference = null)
+    {
+        var catalogRelease = GetOrCreateRelease(manifest, release);
+        catalogRelease.ReleaseDate = releaseDate ?? catalogRelease.ReleaseDate;
+        catalogRelease.GitReference = gitReference ?? catalogRelease.GitReference;
+
+        foreach (var entry in artifacts)
+        {
+            var artifact = new ReleaseCatalogArtifact
+            {
+                FileName = entry.FileName,
+                Sha512 = entry.Sha512
+            };
+
+            catalogRelease.Files[entry.FileName] = artifact;
+
+            if (!TryGetTargetAndRuntime(release, entry.FileName, out var targetId, out var runtimeId))
+            {
+                continue;
+            }
+
+            if (!catalogRelease.Targets.TryGetValue(targetId, out var target))
+            {
+                target = [];
+                catalogRelease.Targets[targetId] = target;
+            }
+
+            target[runtimeId] = artifact;
+        }
+
+        var writeResult = await WriteCache(manifest, cancellationToken);
+        return writeResult switch
+        {
+            Result<Unit, NetworkError>.Success =>
+                new Result<ReleaseCatalogManifest, NetworkError>.Success(manifest),
+            Result<Unit, NetworkError>.Failure failure =>
+                new Result<ReleaseCatalogManifest, NetworkError>.Failure(failure.Error),
             _ => throw new InvalidOperationException("Unexpected Result type")
         };
     }
 
-    public async Task<ReleaseCatalogArtifact?> FindArtifact(Release release, CancellationToken cancellationToken)
-    {
-        var manifest = await TryReadManifest(cancellationToken);
-        if (manifest is null)
-        {
-            return null;
-        }
+    private static bool IsReleaseIndexFresh(ReleaseCatalogManifest manifest) =>
+        manifest.LastUpdated is { } lastUpdated &&
+        DateTimeOffset.UtcNow - lastUpdated <= CacheTtl;
 
-        var targetId = GetCatalogTargetId(release);
-        var runtimeId = release.RuntimeEnvironment.Name();
-
-        var releaseTypeId = GetReleaseTypeId(release);
-        return manifest.TryGetValue(release.Version, out var version) &&
-               version.TryGetValue(releaseTypeId, out var catalogRelease) &&
-               catalogRelease.TryGetValue(targetId, out var target) &&
-               target.TryGetValue(runtimeId, out var artifact)
-            ? artifact
-            : null;
-    }
-
-    public async Task RecordArtifact(Release release, string fileName, string sha512, CancellationToken cancellationToken)
-    {
-        var manifest = await TryReadManifest(cancellationToken) ?? [];
-        var targetId = GetCatalogTargetId(release);
-        var runtimeId = release.RuntimeEnvironment.Name();
-
-        var releaseTypeId = GetReleaseTypeId(release);
-
-        if (!manifest.TryGetValue(release.Version, out var version))
-        {
-            version = [];
-            manifest[release.Version] = version;
-        }
-
-        if (!version.TryGetValue(releaseTypeId, out var catalogRelease))
-        {
-            catalogRelease = [];
-            version[releaseTypeId] = catalogRelease;
-        }
-
-        if (!catalogRelease.TryGetValue(targetId, out var target))
-        {
-            target = [];
-            catalogRelease[targetId] = target;
-        }
-
-        target[runtimeId] = new ReleaseCatalogArtifact
-        {
-            FileName = fileName,
-            Sha512 = sha512
-        };
-
-        await WriteCacheBestEffort(manifest, cancellationToken);
-    }
-
-    private bool IsCacheFresh()
+    private async Task<Result<ReleaseCatalogRead, NetworkError>> ReadCatalogState(CancellationToken cancellationToken)
     {
         try
         {
-            var file = new FileInfo(pathService.ReleasesPath);
-            return file.Exists && DateTimeOffset.UtcNow - file.LastWriteTimeUtc <= CacheTtl;
+            if (!File.Exists(pathService.ReleasesPath))
+            {
+                return new Result<ReleaseCatalogRead, NetworkError>.Success(new ReleaseCatalogRead.MissingOrInvalid());
+            }
+
+            await using var stream = File.OpenRead(pathService.ReleasesPath);
+            var manifest = await JsonSerializer.DeserializeAsync(stream, ReleaseCatalogJsonContext.Default.ReleaseCatalogManifest, cancellationToken);
+            return manifest is { LastUpdated: not null, Releases: not null }
+                ? new Result<ReleaseCatalogRead, NetworkError>.Success(new ReleaseCatalogRead.Found(manifest))
+                : new Result<ReleaseCatalogRead, NetworkError>.Success(new ReleaseCatalogRead.MissingOrInvalid());
+        }
+        catch (JsonException ex)
+        {
+            logger.LogWarning(ex, "Release catalog at {ReleasesPath} is invalid; rebuilding from remote", pathService.ReleasesPath);
+            return new Result<ReleaseCatalogRead, NetworkError>.Success(new ReleaseCatalogRead.MissingOrInvalid());
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
         {
-            logger.LogWarning(ex, "Failed to inspect release catalog at {ReleasesPath}; refreshing from remote", pathService.ReleasesPath);
-            return false;
+            return new Result<ReleaseCatalogRead, NetworkError>.Failure(CatalogIoFailure("read", ex));
         }
     }
 
-    private async Task<string[]> ReadCachedReleaseIds(CancellationToken cancellationToken)
+    private async Task<Result<Unit, NetworkError>> WriteCache(ReleaseCatalogManifest manifest, CancellationToken cancellationToken)
     {
-        var manifest = await TryReadManifest(cancellationToken);
-        if (manifest is null)
-        {
-            return [];
-        }
-
-        return SortReleaseIds(GetReleaseIds(manifest));
-    }
-
-    private async Task<ReleaseCatalogManifest?> TryReadManifest(CancellationToken cancellationToken)
-    {
-        if (!File.Exists(pathService.ReleasesPath))
-        {
-            return null;
-        }
+        var tempPath = $"{pathService.ReleasesPath}.{Guid.NewGuid():N}.tmp";
 
         try
         {
-            await using var stream = File.OpenRead(pathService.ReleasesPath);
-            return await JsonSerializer.DeserializeAsync(stream, ReleaseCatalogJsonContext.Default.ReleaseCatalogManifest, cancellationToken);
+            if (Path.GetDirectoryName(pathService.ReleasesPath) is { } directory)
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            await using (var stream = File.Create(tempPath))
+            {
+                await JsonSerializer.SerializeAsync(stream, manifest, ReleaseCatalogJsonContext.Default.ReleaseCatalogManifest, cancellationToken);
+                await stream.FlushAsync(cancellationToken);
+            }
+
+            File.Move(tempPath, pathService.ReleasesPath, true);
+            return new Result<Unit, NetworkError>.Success(Unit.Value);
         }
-        catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
         {
-            logger.LogWarning(ex, "Failed to read release catalog at {ReleasesPath}; refreshing from remote", pathService.ReleasesPath);
-            return null;
+            TryDeleteTempFile(tempPath);
+            return new Result<Unit, NetworkError>.Failure(CatalogIoFailure("write", ex));
         }
     }
 
-    private async Task WriteCacheBestEffort(ReleaseCatalogManifest manifest, CancellationToken cancellationToken)
+    private async Task<Result<ReleaseCatalogManifest, NetworkError>> ReadCatalogOrRebuild(CancellationToken cancellationToken)
     {
-        try
+        var readResult = await ReadCatalogState(cancellationToken);
+        return readResult switch
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(pathService.ReleasesPath)!);
-            await using var stream = File.Create(pathService.ReleasesPath);
-            await JsonSerializer.SerializeAsync(stream, manifest, ReleaseCatalogJsonContext.Default.ReleaseCatalogManifest, cancellationToken);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            logger.LogWarning(ex, "Failed to write release catalog at {ReleasesPath}; continuing with remote release ids", pathService.ReleasesPath);
-        }
+            Result<ReleaseCatalogRead, NetworkError>.Success { Value: ReleaseCatalogRead.Found(var manifest) } =>
+                new Result<ReleaseCatalogManifest, NetworkError>.Success(manifest),
+            Result<ReleaseCatalogRead, NetworkError>.Success =>
+                await RefreshCatalog(null, cancellationToken),
+            Result<ReleaseCatalogRead, NetworkError>.Failure failure =>
+                new Result<ReleaseCatalogManifest, NetworkError>.Failure(failure.Error),
+            _ => throw new InvalidOperationException("Unexpected Result type")
+        };
     }
 
-    private async Task<Result<string[], NetworkError>> RefreshCache(IEnumerable<string> remoteReleaseIds, CancellationToken cancellationToken)
+    private async Task<Result<ReleaseCatalogManifest, NetworkError>> RefreshCatalog(
+        ReleaseCatalogManifest? existing,
+        CancellationToken cancellationToken)
     {
-        var existing = await TryReadManifest(cancellationToken);
+        var remote = await downloadClient.ListReleases(cancellationToken);
+        return remote switch
+        {
+            Result<IEnumerable<string>, NetworkError>.Success success =>
+                await WriteReleaseIndex(success.Value, existing, cancellationToken),
+            Result<IEnumerable<string>, NetworkError>.Failure failure =>
+                new Result<ReleaseCatalogManifest, NetworkError>.Failure(failure.Error),
+            _ => throw new InvalidOperationException("Unexpected Result type")
+        };
+    }
+
+    private async Task<Result<ReleaseCatalogManifest, NetworkError>> WriteReleaseIndex(
+        IEnumerable<string> remoteReleaseIds,
+        ReleaseCatalogManifest? existing,
+        CancellationToken cancellationToken)
+    {
         var manifest = CreateManifest(remoteReleaseIds, existing);
-        var releaseIds = SortReleaseIds(GetReleaseIds(manifest));
+        manifest.LastUpdated = DateTimeOffset.UtcNow;
 
-        await WriteCacheBestEffort(manifest, cancellationToken);
-
-        return new Result<string[], NetworkError>.Success(releaseIds);
+        var writeResult = await WriteCache(manifest, cancellationToken);
+        return writeResult switch
+        {
+            Result<Unit, NetworkError>.Success =>
+                new Result<ReleaseCatalogManifest, NetworkError>.Success(manifest),
+            Result<Unit, NetworkError>.Failure failure =>
+                new Result<ReleaseCatalogManifest, NetworkError>.Failure(failure.Error),
+            _ => throw new InvalidOperationException("Unexpected Result type")
+        };
     }
 
     private static ReleaseCatalogManifest CreateManifest(IEnumerable<string> releaseIds, ReleaseCatalogManifest? existing)
@@ -183,24 +324,79 @@ public sealed class ReleaseCatalog(
         {
             var releaseTypeId = GetReleaseTypeId(release);
 
-            if (!manifest.TryGetValue(release.Version, out var version))
+            if (!manifest.Releases.TryGetValue(release.Version, out var version))
             {
                 version = [];
-                manifest[release.Version] = version;
+                manifest.Releases[release.Version] = version;
             }
 
-            version[releaseTypeId] = existing is not null &&
-                                     existing.TryGetValue(release.Version, out var existingVersion) &&
+            version[releaseTypeId] = existing?.Releases is not null &&
+                                     existing.Releases.TryGetValue(release.Version, out var existingVersion) &&
                                      existingVersion.TryGetValue(releaseTypeId, out var catalogRelease)
                 ? catalogRelease
-                : [];
+                : new ReleaseCatalogRelease();
         }
 
         return manifest;
     }
 
+    private static ReleaseCatalogRelease GetOrCreateRelease(ReleaseCatalogManifest manifest, Release release)
+    {
+        var releaseTypeId = GetReleaseTypeId(release);
+
+        if (!manifest.Releases.TryGetValue(release.Version, out var version))
+        {
+            version = [];
+            manifest.Releases[release.Version] = version;
+        }
+
+        if (!version.TryGetValue(releaseTypeId, out var catalogRelease))
+        {
+            catalogRelease = new ReleaseCatalogRelease();
+            version[releaseTypeId] = catalogRelease;
+        }
+
+        return catalogRelease;
+    }
+
     private static IEnumerable<string> GetReleaseIds(ReleaseCatalogManifest manifest) =>
-        manifest.SelectMany(version => version.Value.Keys.Select(releaseTypeId => $"{version.Key}-{releaseTypeId}"));
+        manifest.Releases.SelectMany(version => version.Value.Keys.Select(releaseTypeId => $"{version.Key}-{releaseTypeId}"));
+
+    private static ReleaseArtifact? FindArtifact(ReleaseCatalogManifest manifest, Release release)
+    {
+        var targetId = GetCatalogTargetId(release);
+        var runtimeId = release.RuntimeEnvironment.Name();
+
+        var releaseTypeId = GetReleaseTypeId(release);
+        return manifest.Releases.TryGetValue(release.Version, out var version) &&
+               version.TryGetValue(releaseTypeId, out var catalogRelease) &&
+               catalogRelease.Targets.TryGetValue(targetId, out var target) &&
+               target.TryGetValue(runtimeId, out var artifact)
+            ? new ReleaseArtifact(artifact.FileName, artifact.Sha512)
+            : null;
+    }
+
+    private static ReleaseCatalogManifest? GetExistingManifest(ReleaseCatalogRead read) =>
+        read is ReleaseCatalogRead.Found(var manifest) ? manifest : null;
+
+    private NetworkError CatalogIoFailure(string action, Exception ex) =>
+        new NetworkError.ConnectionFailure(
+            $"Failed to {action} release catalog at {pathService.ReleasesPath}",
+            ex.Message);
+
+    private static void TryDeleteTempFile(string tempPath)
+    {
+        try
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+        }
+    }
 
     private static string[] SortReleaseIds(IEnumerable<string> releaseIds) =>
         releaseIds
@@ -214,8 +410,64 @@ public sealed class ReleaseCatalog(
     private static string GetReleaseTypeId(Release release) =>
         release.Type?.ToString() ?? "unknown";
 
+    internal static IReadOnlyList<ReleaseCatalogArtifactEntry> ParseSha512SumsContent(string content)
+    {
+        var artifacts = new List<ReleaseCatalogArtifactEntry>();
+        var lines = content.Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var line in lines)
+        {
+            var parts = line.Split([' '], 2, StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length != 2)
+            {
+                continue;
+            }
+
+            var sha512 = parts[0].Trim();
+            if (sha512.Length != 128 || sha512.Any(character => !Uri.IsHexDigit(character)))
+            {
+                continue;
+            }
+
+            artifacts.Add(new ReleaseCatalogArtifactEntry(parts[1].Trim(), sha512));
+        }
+
+        return artifacts;
+    }
+
+    private static bool TryGetTargetAndRuntime(Release release, string fileName, out string targetId, out string runtimeId)
+    {
+        targetId = "";
+        runtimeId = "";
+
+        const string archiveSuffix = ".zip";
+        var prefix = $"Godot_v{release.ReleaseName}_";
+        if (!fileName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase) ||
+            !fileName.EndsWith(archiveSuffix, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        var rawTarget = fileName[prefix.Length..^archiveSuffix.Length];
+        if (rawTarget.Contains("export_templates", StringComparison.OrdinalIgnoreCase) ||
+            rawTarget.Equals("web_editor", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        runtimeId = rawTarget.StartsWith("mono_", StringComparison.OrdinalIgnoreCase)
+            ? RuntimeEnvironment.Mono.Name()
+            : RuntimeEnvironment.Standard.Name();
+
+        targetId = NormalizeCatalogTargetId(rawTarget);
+        return true;
+    }
+
     private static string GetCatalogTargetId(Release release) =>
-        release.PlatformString switch
+        NormalizeCatalogTargetId(release.PlatformString);
+
+    private static string NormalizeCatalogTargetId(string? targetId) =>
+        targetId switch
         {
             null => "unknown",
             "mono_macos.universal" => "macos.universal",
@@ -230,29 +482,45 @@ public sealed class ReleaseCatalog(
             "mono_windows_arm64" => "windows_arm64",
             "mono_win64" => "win64",
             "mono_win32" => "win32",
-            var target when target.EndsWith(".exe", StringComparison.Ordinal) => target[..^4],
-            var target => target
+            var value when value.EndsWith(".exe", StringComparison.Ordinal) => value[..^4],
+            var value => value
         };
 }
+
+public sealed record ReleaseCatalogArtifactEntry(string FileName, string Sha512);
 
 /// <summary>
 ///     Version -> release type -> target/platform -> runtime -> artifact.
 /// </summary>
-public sealed class ReleaseCatalogManifest : Dictionary<string, ReleaseCatalogVersion>
+public sealed class ReleaseCatalogManifest
 {
+    [JsonPropertyName("lastUpdated")]
+    public DateTimeOffset? LastUpdated { get; set; }
+
+    [JsonPropertyName("releases")]
+    public Dictionary<string, ReleaseCatalogVersion> Releases { get; init; } = [];
 }
 
-public sealed class ReleaseCatalogVersion : Dictionary<string, ReleaseCatalogRelease>
+public sealed class ReleaseCatalogVersion : Dictionary<string, ReleaseCatalogRelease>;
+
+public sealed class ReleaseCatalogRelease
 {
+    [JsonPropertyName("releaseDate")]
+    public long? ReleaseDate { get; set; }
+
+    [JsonPropertyName("gitReference")]
+    public string? GitReference { get; set; }
+
+    [JsonPropertyName("targets")]
+    public ReleaseCatalogTargets Targets { get; init; } = [];
+
+    [JsonPropertyName("files")]
+    public Dictionary<string, ReleaseCatalogArtifact> Files { get; init; } = [];
 }
 
-public sealed class ReleaseCatalogRelease : Dictionary<string, ReleaseCatalogTarget>
-{
-}
+public sealed class ReleaseCatalogTargets : Dictionary<string, ReleaseCatalogTarget>;
 
-public sealed class ReleaseCatalogTarget : Dictionary<string, ReleaseCatalogArtifact>
-{
-}
+public sealed class ReleaseCatalogTarget : Dictionary<string, ReleaseCatalogArtifact>;
 
 public sealed class ReleaseCatalogArtifact
 {

--- a/Fgvm/Godot/ReleaseManager.cs
+++ b/Fgvm/Godot/ReleaseManager.cs
@@ -6,31 +6,55 @@ namespace Fgvm.Godot;
 public interface IReleaseManager
 {
     Task<Result<IEnumerable<string>, NetworkError>> ListReleases(CancellationToken cancellationToken);
-    Task<Result<IEnumerable<string>, NetworkError>> SearchRemoteReleases(string[] query, CancellationToken cancellationToken);
+
+    Task<Result<IEnumerable<string>, NetworkError>> SearchRemoteReleases(
+        string[] query,
+        ReleaseFetchMode fetchMode,
+        CancellationToken cancellationToken);
+
     Task<Result<string, NetworkError>> GetSha512(Release release, CancellationToken cancellationToken);
-    Task<HttpResponseMessage> GetZipFile(string filename, Release release, CancellationToken cancellationToken);
+    Task<Result<HttpResponseMessage, NetworkError>> GetZipFile(string filename, Release release, CancellationToken cancellationToken);
 
     Release? TryFindReleaseByQuery(string[] query, string[] releaseNames);
+    Result<Release, QueryError> ResolveReleaseQuery(string[] query, string[] releaseIds);
     IEnumerable<string> FilterReleasesByQuery(string[] query, string[] releaseNames, bool chronological = false);
     string? FindCompatibleVersion(string projectVersion, bool isDotNet, IEnumerable<string> installedVersions);
+    Result<string, CompatibilityError> FindCompatibleVersionResult(string projectVersion, bool isDotNet, IEnumerable<string> installedReleaseIds);
 
     Release? TryCreateRelease(string versionString);
 }
 
-public sealed class ReleaseManager(IHostSystem hostSystem, PlatformStringProvider platformStringProvider, IDownloadClient downloadClient) : IReleaseManager
+public sealed class ReleaseManager(
+    IHostSystem hostSystem,
+    PlatformStringProvider platformStringProvider,
+    IDownloadClient downloadClient,
+    IReleaseCatalog releaseCatalog) : IReleaseManager
 {
-    public async Task<Result<IEnumerable<string>, NetworkError>> ListReleases(CancellationToken cancellationToken) =>
-        await downloadClient.ListReleases(cancellationToken);
-
-    public async Task<Result<IEnumerable<string>, NetworkError>> SearchRemoteReleases(string[] query, CancellationToken cancellationToken)
+    public async Task<Result<IEnumerable<string>, NetworkError>> ListReleases(CancellationToken cancellationToken)
     {
-        var result = await ListReleases(cancellationToken);
+        var result = await releaseCatalog.ReadReleaseIds(ReleaseFetchMode.UseCache, cancellationToken);
         return result switch
         {
-            Result<IEnumerable<string>, NetworkError>.Success(var releases) =>
+            Result<string[], NetworkError>.Success(var releases) =>
+                new Result<IEnumerable<string>, NetworkError>.Success(releases),
+            Result<string[], NetworkError>.Failure(var error) =>
+                new Result<IEnumerable<string>, NetworkError>.Failure(error),
+            _ => throw new InvalidOperationException("Unexpected Result type")
+        };
+    }
+
+    public async Task<Result<IEnumerable<string>, NetworkError>> SearchRemoteReleases(
+        string[] query,
+        ReleaseFetchMode fetchMode,
+        CancellationToken cancellationToken)
+    {
+        var result = await releaseCatalog.ReadReleaseIds(fetchMode, cancellationToken);
+        return result switch
+        {
+            Result<string[], NetworkError>.Success(var releases) =>
                 new Result<IEnumerable<string>, NetworkError>.Success(
-                    FilterReleasesByQuery(query, releases.ToArray(), true)),
-            Result<IEnumerable<string>, NetworkError>.Failure(var error) =>
+                    FilterReleasesByQuery(query, releases, true)),
+            Result<string[], NetworkError>.Failure(var error) =>
                 new Result<IEnumerable<string>, NetworkError>.Failure(error),
             _ => throw new InvalidOperationException("Unexpected Result type")
         };
@@ -39,37 +63,36 @@ public sealed class ReleaseManager(IHostSystem hostSystem, PlatformStringProvide
     public async Task<Result<string, NetworkError>> GetSha512(Release release, CancellationToken cancellationToken) =>
         await downloadClient.GetSha512(release, cancellationToken);
 
-    public async Task<HttpResponseMessage> GetZipFile(string filename, Release release, CancellationToken cancellationToken) =>
+    public async Task<Result<HttpResponseMessage, NetworkError>> GetZipFile(string filename, Release release, CancellationToken cancellationToken) =>
         await downloadClient.GetZipFile(filename, release, cancellationToken);
 
-    /// <summary>
-    ///     A way to handle the various argument possibilities for filtering releases by query
-    /// </summary>
-    /// <param name="query"></param>
-    /// <param name="releaseNames"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentException"></exception>
-    // TODO: Replace with Result<Release, QueryError> FindReleaseByQuery(string[] query, string[] releaseNames)
     public Release? TryFindReleaseByQuery(string[] query, string[] releaseNames)
     {
-        return query switch
+        var result = ResolveReleaseQuery(query, releaseNames);
+        return result switch
         {
-            // We handle empty query at the call site
-            [] => throw new ArgumentException("Empty query"),
-            // Handle latest stable standard
-            ["latest"] => TryFilterLatest("stable", "standard", releaseNames),
-            // Handle latest stable by with runtime
-            ["latest", var releaseType and ("mono" or "standard")] => TryFilterLatest("stable", releaseType, releaseNames),
-            // Handle latest standard with release type
-            ["latest", var releaseType] when ReleaseType.Prefixes.Contains(releaseType, StringComparer.OrdinalIgnoreCase)
-                => TryFilterLatest(releaseType, "standard", releaseNames),
-            // Handle latest with release type and runtime
-            ["latest", var releaseType, var runtime] when ReleaseType.Prefixes.Contains(releaseType, StringComparer.OrdinalIgnoreCase) &&
-                                                          runtime is "mono" or "standard"
-                => TryFilterLatest(releaseType, runtime, releaseNames),
-            // Explicit version, i.e. `4.2-stable(-mono)`
-            _ => TryFilterRelease(query, releaseNames)
+            Result<Release, QueryError>.Success(var release) => release,
+            Result<Release, QueryError>.Failure(QueryError.EmptyQuery) => throw new ArgumentException("Empty query"),
+            Result<Release, QueryError>.Failure(QueryError.InvalidQuery(var message)) => throw new ArgumentException(message),
+            Result<Release, QueryError>.Failure(QueryError.NotFound) => null,
+            _ => throw new InvalidOperationException("Unexpected Result type")
         };
+    }
+
+    public Result<Release, QueryError> ResolveReleaseQuery(string[] query, string[] releaseIds)
+    {
+        try
+        {
+            return query.Length == 0
+                ? new Result<Release, QueryError>.Failure(new QueryError.EmptyQuery())
+                : FindReleaseByQuery(query, releaseIds) is { } release
+                    ? new Result<Release, QueryError>.Success(release)
+                    : new Result<Release, QueryError>.Failure(new QueryError.NotFound(string.Join(" ", query)));
+        }
+        catch (ArgumentException ex)
+        {
+            return new Result<Release, QueryError>.Failure(new QueryError.InvalidQuery(ex.Message));
+        }
     }
 
     public IEnumerable<string> FilterReleasesByQuery(string[] query, string[] releaseNames, bool chronological = false)
@@ -134,14 +157,24 @@ public sealed class ReleaseManager(IHostSystem hostSystem, PlatformStringProvide
         };
     }
 
-    // TODO: Replace with Result<string, CompatibilityError> FindCompatibleVersion(string projectVersion, bool isDotNet, IEnumerable<string> installedVersions)
     public string? FindCompatibleVersion(string projectVersion, bool isDotNet, IEnumerable<string> installedVersions)
     {
-        var versions = installedVersions.ToList();
+        var result = FindCompatibleVersionResult(projectVersion, isDotNet, installedVersions);
+        return result switch
+        {
+            Result<string, CompatibilityError>.Success(var version) => version,
+            Result<string, CompatibilityError>.Failure => null,
+            _ => throw new InvalidOperationException("Unexpected Result type")
+        };
+    }
+
+    public Result<string, CompatibilityError> FindCompatibleVersionResult(string projectVersion, bool isDotNet, IEnumerable<string> installedReleaseIds)
+    {
+        var versions = installedReleaseIds.ToList();
 
         if (versions.Count == 0)
         {
-            return null;
+            return new Result<string, CompatibilityError>.Failure(new CompatibilityError.NoInstalledVersions());
         }
 
         var preferredRuntime = isDotNet ? "mono" : "standard";
@@ -150,7 +183,7 @@ public sealed class ReleaseManager(IHostSystem hostSystem, PlatformStringProvide
         var exactMatch = versions.FirstOrDefault(v => v == projectVersion);
         if (exactMatch != null)
         {
-            return exactMatch;
+            return new Result<string, CompatibilityError>.Success(exactMatch);
         }
 
         // Parse all compatible releases and find the best match
@@ -182,7 +215,7 @@ public sealed class ReleaseManager(IHostSystem hostSystem, PlatformStringProvide
 
         if (compatibleReleases.Length == 0)
         {
-            return null;
+            return new Result<string, CompatibilityError>.Failure(new CompatibilityError.NotFound(projectVersion, isDotNet));
         }
 
         // Use OrderByDescending with the built-in Release.CompareTo for preference ordering
@@ -193,7 +226,29 @@ public sealed class ReleaseManager(IHostSystem hostSystem, PlatformStringProvide
             .OrderByDescending(r => r)
             .First();
 
-        return bestRelease.ReleaseNameWithRuntime;
+        return new Result<string, CompatibilityError>.Success(bestRelease.ReleaseNameWithRuntime);
+    }
+
+    private Release? FindReleaseByQuery(string[] query, string[] releaseNames)
+    {
+        return query switch
+        {
+            // We handle empty query at the call site
+            [] => throw new ArgumentException("Empty query"),
+            // Handle latest stable standard
+            ["latest"] => TryFilterLatest("stable", "standard", releaseNames),
+            // Handle latest stable by with runtime
+            ["latest", var releaseType and ("mono" or "standard")] => TryFilterLatest("stable", releaseType, releaseNames),
+            // Handle latest standard with release type
+            ["latest", var releaseType] when ReleaseType.Prefixes.Contains(releaseType, StringComparer.OrdinalIgnoreCase)
+                => TryFilterLatest(releaseType, "standard", releaseNames),
+            // Handle latest with release type and runtime
+            ["latest", var releaseType, var runtime] when ReleaseType.Prefixes.Contains(releaseType, StringComparer.OrdinalIgnoreCase) &&
+                                                          runtime is "mono" or "standard"
+                => TryFilterLatest(releaseType, runtime, releaseNames),
+            // Explicit version, i.e. `4.2-stable(-mono)`
+            _ => TryFilterRelease(query, releaseNames)
+        };
     }
 
 

--- a/Fgvm/Godot/TuxFamilyClient.cs
+++ b/Fgvm/Godot/TuxFamilyClient.cs
@@ -38,6 +38,10 @@ public class TuxFamilyClient(HttpClient httpClient, ILogger<TuxFamilyClient> log
             return new Result<string, NetworkError>.Failure(
                 new NetworkError.RequestFailure(url, (int)response.StatusCode, body));
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogError("Failed to get SHA512 from TuxFamily for {Version}: {Message}", godotRelease.Version, ex.Message);

--- a/Fgvm/Godot/TuxFamilyClient.cs
+++ b/Fgvm/Godot/TuxFamilyClient.cs
@@ -6,7 +6,7 @@ namespace Fgvm.Godot;
 public interface ITuxFamilyClient
 {
     Task<Result<string, NetworkError>> GetSha512Async(Release godotRelease, CancellationToken cancellationToken);
-    Task<HttpResponseMessage> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken);
+    Task<Result<HttpResponseMessage, NetworkError>> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken);
 }
 
 // Basically exists as a backup for checksums of older versions since GitHub doesn't seem to always have them.
@@ -46,8 +46,7 @@ public class TuxFamilyClient(HttpClient httpClient, ILogger<TuxFamilyClient> log
         }
     }
 
-    // TODO: Replace with Task<Result<HttpResponseMessage, NetworkError>> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken)
-    public async Task<HttpResponseMessage> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken)
+    public async Task<Result<HttpResponseMessage, NetworkError>> GetZipFileAsync(string filename, Release godotRelease, CancellationToken cancellationToken)
     {
         var url = BuildUrl(filename, godotRelease);
 
@@ -60,17 +59,23 @@ public class TuxFamilyClient(HttpClient httpClient, ILogger<TuxFamilyClient> log
             if (response.IsSuccessStatusCode)
             {
                 logger.LogInformation("Found {File} for {Release} at TuxFamily", filename, godotRelease.ReleaseNameWithRuntime);
-                return response;
+                return new Result<HttpResponseMessage, NetworkError>.Success(response);
             }
 
             var body = await response.Content.ReadAsStringAsync(cancellationToken);
             logger.LogError("{Url} returned {StatusCode}. Body: {Body}", url, response.StatusCode, body);
-            throw new HttpRequestException($"TuxFamily zip file request failed: {response.StatusCode}");
+            return new Result<HttpResponseMessage, NetworkError>.Failure(
+                new NetworkError.RequestFailure(url, (int)response.StatusCode, body));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             logger.LogError("Failed to get zip file from TuxFamily for {ReleaseNameWithRuntime}: {Message}", godotRelease.ReleaseNameWithRuntime, ex.Message);
-            throw;
+            return new Result<HttpResponseMessage, NetworkError>.Failure(
+                new NetworkError.ConnectionFailure(ex.Message));
         }
     }
 

--- a/Fgvm/Services/InstallationService.cs
+++ b/Fgvm/Services/InstallationService.cs
@@ -84,8 +84,20 @@ public class InstallationService(
             progress.Report(new OperationProgress<InstallationStage>(InstallationStage.Downloading, $"Downloading {installPathBase}..."));
 
             const int bufferSize = 32768;
-            var catalogArtifact = await releaseCatalog.FindArtifact(godotRelease, cancellationToken);
-            var zipFileName = catalogArtifact?.FileName ?? godotRelease.ZipFileName;
+            ReleaseArtifact artifact;
+            switch (await releaseCatalog.FindOrHydrateArtifact(godotRelease, cancellationToken))
+            {
+                case Result<ReleaseArtifact, NetworkError>.Success success:
+                    artifact = success.Value;
+                    break;
+                case Result<ReleaseArtifact, NetworkError>.Failure failure:
+                    return new Result<InstallationOutcome, InstallationError>.Failure(
+                        new InstallationError.Failed($"Release catalog hydration failed for {godotRelease.ReleaseName}: {failure.Error}"));
+                default:
+                    throw new InvalidOperationException("Unexpected Result type");
+            }
+
+            var zipFileName = artifact.FileName;
             var responseResult = await releaseManager.GetZipFile(zipFileName, godotRelease, cancellationToken);
 
             HttpResponseMessage response;
@@ -147,7 +159,7 @@ public class InstallationService(
                 }
             }
 
-            var checksumResult = await VerifyChecksum(godotRelease, zipFileName, catalogArtifact, memStream, progress, cancellationToken);
+            var checksumResult = await VerifyChecksum(zipFileName, artifact, memStream, progress, cancellationToken);
             ChecksumVerification checksumStatus;
             switch (checksumResult)
             {
@@ -276,54 +288,16 @@ public class InstallationService(
     }
 
     private async Task<Result<ChecksumVerification, InstallationError>> VerifyChecksum(
-        Release godotRelease,
         string zipFileName,
-        ReleaseCatalogArtifact? catalogArtifact,
+        ReleaseArtifact artifact,
         MemoryStream memStream,
         IProgress<OperationProgress<InstallationStage>> progress,
         CancellationToken cancellationToken)
     {
-        var expectedHash = catalogArtifact?.Sha512;
-        ChecksumVerification checksumStatus = new ChecksumVerification.Skipped();
-
-        if (expectedHash is null && ShouldUseLegacyChecksumFallback(godotRelease))
+        if (artifact.Sha512 is not { } expectedHash)
         {
-            progress.Report(new OperationProgress<InstallationStage>(InstallationStage.VerifyingChecksum, "Fetching checksum..."));
-
-            switch (await releaseManager.GetSha512(godotRelease, cancellationToken))
-            {
-                case Result<string, NetworkError>.Success success:
-                    switch (ParseSha512SumsContent(zipFileName, success.Value))
-                    {
-                        case Result<string, InstallationError.ChecksumParseError>.Success parsed:
-                            expectedHash = parsed.Value;
-                            await releaseCatalog.RecordArtifact(godotRelease, zipFileName, expectedHash, cancellationToken);
-                            break;
-                        case Result<string, InstallationError.ChecksumParseError>.Failure failure:
-                            logger.LogWarning("Checksum entry not found for {FileName} in SHA512-SUMS.txt, continuing installation without verification",
-                                zipFileName);
-                            checksumStatus = new ChecksumVerification.Failed(
-                                new NetworkError.ConnectionFailure(failure.Error.Content));
-                            break;
-                        default:
-                            throw new InvalidOperationException("Unexpected Result type");
-                    }
-
-                    break;
-                case Result<string, NetworkError>.Failure failure:
-                    logger.LogWarning("Failed to fetch checksum for {ReleaseNameWithRuntime}, continuing installation without verification",
-                        godotRelease.ReleaseNameWithRuntime);
-
-                    checksumStatus = new ChecksumVerification.Failed(failure.Error);
-                    break;
-                default:
-                    throw new InvalidOperationException("Unexpected Result type");
-            }
-        }
-
-        if (expectedHash is null)
-        {
-            return new Result<ChecksumVerification, InstallationError>.Success(checksumStatus);
+            logger.LogWarning("Checksum unavailable for {FileName}. Installation will continue without verification", zipFileName);
+            return new Result<ChecksumVerification, InstallationError>.Success(new ChecksumVerification.Unavailable());
         }
 
         progress.Report(new OperationProgress<InstallationStage>(InstallationStage.VerifyingChecksum, "Verifying checksum..."));
@@ -341,36 +315,6 @@ public class InstallationService(
 
         logger.LogInformation("Checksum verified successfully for {FileName}", zipFileName);
         return new Result<ChecksumVerification, InstallationError>.Success(new ChecksumVerification.Verified());
-    }
-
-    private static bool ShouldUseLegacyChecksumFallback(Release release) =>
-        release.Major > 3 || release is { Major: 3, Minor: >= 3 };
-
-    public static Result<string, InstallationError.ChecksumParseError> ParseSha512SumsContent(string fileName, string content)
-    {
-        var lines = content.Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries);
-
-        foreach (var line in lines)
-        {
-            var parts = line.Split([' '], 2, StringSplitOptions.RemoveEmptyEntries);
-
-            if (parts.Length != 2)
-            {
-                continue;
-            }
-
-            var (currentHash, currentFile) = (parts[0].Trim(), parts[1].Trim());
-
-            if (currentFile != fileName)
-            {
-                continue;
-            }
-
-            return new Result<string, InstallationError.ChecksumParseError>.Success(currentHash);
-        }
-
-        return new Result<string, InstallationError.ChecksumParseError>.Failure(
-            new InstallationError.ChecksumParseError($"Checksum entry for {fileName} not found in SHA512-SUMS.txt"));
     }
 
 }

--- a/Fgvm/Services/InstallationService.cs
+++ b/Fgvm/Services/InstallationService.cs
@@ -40,12 +40,13 @@ public interface IInstallationService
         IProgress<OperationProgress<InstallationStage>> progress, bool setAsDefault = false,
         CancellationToken cancellationToken = default);
 
-    Task<string[]> FetchReleaseNames(CancellationToken cancellationToken, bool remote = false);
+    Task<string[]> FetchReleaseNames(CancellationToken cancellationToken, ReleaseFetchMode fetchMode = ReleaseFetchMode.UseCache);
 }
 
 public class InstallationService(
     IHostSystem hostSystem,
     IReleaseManager releaseManager,
+    IReleaseCatalog releaseCatalog,
     IPathService pathService,
     ILogger<InstallationService> logger)
     : IInstallationService
@@ -83,7 +84,24 @@ public class InstallationService(
             progress.Report(new OperationProgress<InstallationStage>(InstallationStage.Downloading, $"Downloading {installPathBase}..."));
 
             const int bufferSize = 32768;
-            using var response = await releaseManager.GetZipFile(godotRelease.ZipFileName, godotRelease, cancellationToken);
+            var catalogArtifact = await releaseCatalog.FindArtifact(godotRelease, cancellationToken);
+            var zipFileName = catalogArtifact?.FileName ?? godotRelease.ZipFileName;
+            var responseResult = await releaseManager.GetZipFile(zipFileName, godotRelease, cancellationToken);
+
+            HttpResponseMessage response;
+            switch (responseResult)
+            {
+                case Result<HttpResponseMessage, NetworkError>.Success downloadSuccess:
+                    response = downloadSuccess.Value;
+                    break;
+                case Result<HttpResponseMessage, NetworkError>.Failure downloadFailure:
+                    return new Result<InstallationOutcome, InstallationError>.Failure(
+                        new InstallationError.Failed($"Download failed for {zipFileName}: {downloadFailure.Error}"));
+                default:
+                    throw new InvalidOperationException("Unexpected Result type");
+            }
+
+            using var responseOwner = response;
 
             var contentLength = response.Content.Headers.ContentLength ?? 0;
 
@@ -129,52 +147,17 @@ public class InstallationService(
                 }
             }
 
-            // TODO: Revisit this to use the godot-builds JSON artifacts instead
-            // Verify checksum if available
-            ChecksumVerification checksumStatus = new ChecksumVerification.Skipped();
-
-            if (ShouldVerifyChecksum(godotRelease))
+            var checksumResult = await VerifyChecksum(godotRelease, zipFileName, catalogArtifact, memStream, progress, cancellationToken);
+            ChecksumVerification checksumStatus;
+            switch (checksumResult)
             {
-                progress.Report(new OperationProgress<InstallationStage>(InstallationStage.VerifyingChecksum, "Verifying checksum..."));
-                memStream.Position = 0;
-
-                var sha512Result = await releaseManager.GetSha512(godotRelease, cancellationToken);
-
-                if (sha512Result is Result<string, NetworkError>.Success success)
-                {
-                    var sha512String = success.Value;
-                    if (TryParseSha512SumsContent(godotRelease.ZipFileName, sha512String) is not { } expectedHash)
-                    {
-                        logger.LogWarning("Checksum entry not found for {FileName} in SHA512-SUMS.txt, continuing installation without verification",
-                            godotRelease.ZipFileName);
-
-                        checksumStatus = new ChecksumVerification.Failed(
-                            new NetworkError.ConnectionFailure($"Checksum entry for {godotRelease.ZipFileName} not found in SHA512-SUMS.txt"));
-                    }
-                    else
-                    {
-                        var calculatedChecksum = await CalculateChecksum(memStream, cancellationToken);
-
-                        if (!calculatedChecksum.Equals(expectedHash, StringComparison.OrdinalIgnoreCase))
-                        {
-                            logger.LogError("Checksum mismatch for {FileName}. Expected: {Expected}, Actual: {Actual}",
-                                godotRelease.ZipFileName, expectedHash, calculatedChecksum);
-
-                            return new Result<InstallationOutcome, InstallationError>.Failure(
-                                new InstallationError.ChecksumMismatch(expectedHash, calculatedChecksum, godotRelease.ZipFileName));
-                        }
-
-                        checksumStatus = new ChecksumVerification.Verified();
-                        logger.LogInformation("Checksum verified successfully for {FileName}", godotRelease.ZipFileName);
-                    }
-                }
-                else if (sha512Result is Result<string, NetworkError>.Failure failure)
-                {
-                    logger.LogWarning("Failed to fetch checksum for {ReleaseNameWithRuntime}, continuing installation without verification",
-                        godotRelease.ReleaseNameWithRuntime);
-
-                    checksumStatus = new ChecksumVerification.Failed(failure.Error);
-                }
+                case Result<ChecksumVerification, InstallationError>.Success checksumSuccess:
+                    checksumStatus = checksumSuccess.Value;
+                    break;
+                case Result<ChecksumVerification, InstallationError>.Failure checksumFailure:
+                    return new Result<InstallationOutcome, InstallationError>.Failure(checksumFailure.Error);
+                default:
+                    throw new InvalidOperationException("Unexpected Result type");
             }
 
             progress.Report(new OperationProgress<InstallationStage>(InstallationStage.Extracting, "Extracting files..."));
@@ -191,11 +174,17 @@ public class InstallationService(
                 var symlinkTargetPath = Path.Combine(extractPath, godotRelease.ExecName);
                 var symlinkResult = hostSystem.CreateOrOverwriteSymbolicLink(symlinkTargetPath);
 
-                if (symlinkResult is Result<Unit, SymlinkError>.Failure failure)
+                switch (symlinkResult)
                 {
-                    logger.LogError("Failed to create symlink: {Error}", failure.Error);
-                    hostSystem.RemoveSymbolicLinks();
-                    symlinkWarning = failure.Error;
+                    case Result<Unit, SymlinkError>.Success:
+                        break;
+                    case Result<Unit, SymlinkError>.Failure failure:
+                        logger.LogError("Failed to create symlink: {Error}", failure.Error);
+                        hostSystem.RemoveSymbolicLinks();
+                        symlinkWarning = failure.Error;
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unexpected Result type");
                 }
             }
 
@@ -239,7 +228,7 @@ public class InstallationService(
             var godotRelease = releaseManager.TryFindReleaseByQuery(query, releaseNames);
 
             // Retry with remote fetch if not found
-            godotRelease ??= releaseManager.TryFindReleaseByQuery(query, await FetchReleaseNames(cancellationToken, true));
+            godotRelease ??= releaseManager.TryFindReleaseByQuery(query, await FetchReleaseNames(cancellationToken, ReleaseFetchMode.ForceRemote));
 
             return godotRelease == null
                 ? new Result<InstallationOutcome, InstallationError>.Failure(
@@ -253,51 +242,16 @@ public class InstallationService(
         }
     }
 
-    public async Task<string[]> FetchReleaseNames(CancellationToken cancellationToken, bool remote = false)
+    public async Task<string[]> FetchReleaseNames(CancellationToken cancellationToken, ReleaseFetchMode fetchMode = ReleaseFetchMode.UseCache)
     {
-        var lastWriteTime = File.GetLastWriteTime(pathService.ReleasesPath);
-        var isCacheValid = !remote && File.Exists(pathService.ReleasesPath) && DateTime.Now.AddDays(-1) <= lastWriteTime;
-
-        string[] releaseNames;
-        var fetchedRemote = false;
-
-        if (isCacheValid)
+        var releaseIds = await releaseCatalog.ReadReleaseIds(fetchMode, cancellationToken) switch
         {
-            logger.LogInformation("Reading from {ReleasesPath}, last updated {LastWriteTime}", pathService.ReleasesPath, lastWriteTime);
-            var cachedReleases = await File.ReadAllLinesAsync(pathService.ReleasesPath, cancellationToken);
-            if (cachedReleases.Length > 0)
-            {
-                releaseNames = cachedReleases;
-            }
-            else
-            {
-                logger.LogWarning("Cached releases file is empty, fetching from remote");
-                var result = await releaseManager.ListReleases(cancellationToken);
-                releaseNames = result switch
-                {
-                    Result<IEnumerable<string>, NetworkError>.Success(var releases) => releases.ToArray(),
-                    Result<IEnumerable<string>, NetworkError>.Failure(var error) => throw new HttpRequestException($"Failed to fetch releases: {error}"),
-                    _ => throw new InvalidOperationException("Unexpected Result type")
-                };
+            Result<string[], NetworkError>.Success success => success.Value,
+            Result<string[], NetworkError>.Failure failure => throw new HttpRequestException($"Failed to fetch releases: {failure.Error}"),
+            _ => throw new InvalidOperationException("Unexpected Result type")
+        };
 
-                fetchedRemote = true;
-            }
-        }
-        else
-        {
-            var result = await releaseManager.ListReleases(cancellationToken);
-            releaseNames = result switch
-            {
-                Result<IEnumerable<string>, NetworkError>.Success(var releases) => releases.ToArray(),
-                Result<IEnumerable<string>, NetworkError>.Failure(var error) => throw new HttpRequestException($"Failed to fetch releases: {error}"),
-                _ => throw new InvalidOperationException("Unexpected Result type")
-            };
-
-            fetchedRemote = true;
-        }
-
-        // Always sort releases using Release.CompareTo for consistent ordering
-        var sortedReleases = releaseNames
+        var sortedReleases = releaseIds
             .Select(name => releaseManager.TryCreateRelease($"{name}-standard"))
             .OfType<Release>()
             .OrderByDescending(r => r)
@@ -308,11 +262,6 @@ public class InstallationService(
         {
             logger.LogError("Unable to fetch remote releases");
             return [];
-        }
-
-        if (fetchedRemote)
-        {
-            await File.WriteAllLinesAsync(pathService.ReleasesPath, sortedReleases, cancellationToken);
         }
 
         return sortedReleases;
@@ -326,12 +275,78 @@ public class InstallationService(
         return checksum;
     }
 
-    // TODO: Update once manifest-based releases are used
-    private static bool ShouldVerifyChecksum(Release release) =>
+    private async Task<Result<ChecksumVerification, InstallationError>> VerifyChecksum(
+        Release godotRelease,
+        string zipFileName,
+        ReleaseCatalogArtifact? catalogArtifact,
+        MemoryStream memStream,
+        IProgress<OperationProgress<InstallationStage>> progress,
+        CancellationToken cancellationToken)
+    {
+        var expectedHash = catalogArtifact?.Sha512;
+        ChecksumVerification checksumStatus = new ChecksumVerification.Skipped();
+
+        if (expectedHash is null && ShouldUseLegacyChecksumFallback(godotRelease))
+        {
+            progress.Report(new OperationProgress<InstallationStage>(InstallationStage.VerifyingChecksum, "Fetching checksum..."));
+
+            switch (await releaseManager.GetSha512(godotRelease, cancellationToken))
+            {
+                case Result<string, NetworkError>.Success success:
+                    switch (ParseSha512SumsContent(zipFileName, success.Value))
+                    {
+                        case Result<string, InstallationError.ChecksumParseError>.Success parsed:
+                            expectedHash = parsed.Value;
+                            await releaseCatalog.RecordArtifact(godotRelease, zipFileName, expectedHash, cancellationToken);
+                            break;
+                        case Result<string, InstallationError.ChecksumParseError>.Failure failure:
+                            logger.LogWarning("Checksum entry not found for {FileName} in SHA512-SUMS.txt, continuing installation without verification",
+                                zipFileName);
+                            checksumStatus = new ChecksumVerification.Failed(
+                                new NetworkError.ConnectionFailure(failure.Error.Content));
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected Result type");
+                    }
+
+                    break;
+                case Result<string, NetworkError>.Failure failure:
+                    logger.LogWarning("Failed to fetch checksum for {ReleaseNameWithRuntime}, continuing installation without verification",
+                        godotRelease.ReleaseNameWithRuntime);
+
+                    checksumStatus = new ChecksumVerification.Failed(failure.Error);
+                    break;
+                default:
+                    throw new InvalidOperationException("Unexpected Result type");
+            }
+        }
+
+        if (expectedHash is null)
+        {
+            return new Result<ChecksumVerification, InstallationError>.Success(checksumStatus);
+        }
+
+        progress.Report(new OperationProgress<InstallationStage>(InstallationStage.VerifyingChecksum, "Verifying checksum..."));
+        memStream.Position = 0;
+        var calculatedChecksum = await CalculateChecksum(memStream, cancellationToken);
+
+        if (!calculatedChecksum.Equals(expectedHash, StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogError("Checksum mismatch for {FileName}. Expected: {Expected}, Actual: {Actual}",
+                zipFileName, expectedHash, calculatedChecksum);
+
+            return new Result<ChecksumVerification, InstallationError>.Failure(
+                new InstallationError.ChecksumMismatch(expectedHash, calculatedChecksum, zipFileName));
+        }
+
+        logger.LogInformation("Checksum verified successfully for {FileName}", zipFileName);
+        return new Result<ChecksumVerification, InstallationError>.Success(new ChecksumVerification.Verified());
+    }
+
+    private static bool ShouldUseLegacyChecksumFallback(Release release) =>
         release.Major > 3 || release is { Major: 3, Minor: >= 3 };
 
-    // TODO: Replace with Result<string, ParseError> ParseSha512SumsContent(string fileName, string content)
-    public static string? TryParseSha512SumsContent(string fileName, string content)
+    public static Result<string, InstallationError.ChecksumParseError> ParseSha512SumsContent(string fileName, string content)
     {
         var lines = content.Split(['\n', '\r'], StringSplitOptions.RemoveEmptyEntries);
 
@@ -351,9 +366,11 @@ public class InstallationService(
                 continue;
             }
 
-            return currentHash;
+            return new Result<string, InstallationError.ChecksumParseError>.Success(currentHash);
         }
 
-        return null;
+        return new Result<string, InstallationError.ChecksumParseError>.Failure(
+            new InstallationError.ChecksumParseError($"Checksum entry for {fileName} not found in SHA512-SUMS.txt"));
     }
+
 }

--- a/Fgvm/Types/Installation.cs
+++ b/Fgvm/Types/Installation.cs
@@ -8,11 +8,8 @@ public abstract record ChecksumVerification
     /// <summary>Checksum was verified successfully</summary>
     public record Verified : ChecksumVerification;
 
-    /// <summary>Checksum verification was skipped (version too old)</summary>
-    public record Skipped : ChecksumVerification;
-
-    /// <summary>Checksum verification failed due to network error</summary>
-    public record Failed(NetworkError Error) : ChecksumVerification;
+    /// <summary>Checksum metadata was unavailable for the selected artifact</summary>
+    public record Unavailable : ChecksumVerification;
 }
 
 /// <summary>
@@ -38,6 +35,4 @@ public abstract record InstallationError
     /// <summary>Checksum mismatch - actual security issue</summary>
     public record ChecksumMismatch(string Expected, string Actual, string FileName) : InstallationError;
 
-    /// <summary>Checksum content couldn't be parsed</summary>
-    public record ChecksumParseError(string Content) : InstallationError;
 }

--- a/Fgvm/Types/ReleaseResolution.cs
+++ b/Fgvm/Types/ReleaseResolution.cs
@@ -1,0 +1,17 @@
+namespace Fgvm.Types;
+
+public abstract record QueryError
+{
+    public sealed record EmptyQuery : QueryError;
+
+    public sealed record InvalidQuery(string Message) : QueryError;
+
+    public sealed record NotFound(string Query) : QueryError;
+}
+
+public abstract record CompatibilityError
+{
+    public sealed record NoInstalledVersions : CompatibilityError;
+
+    public sealed record NotFound(string ProjectVersion, bool IsDotNet) : CompatibilityError;
+}


### PR DESCRIPTION
Introduce manifest-backed caching and add a `--no-cache` flag to force refreshing when searching for releases.