### PR TITLE
feat: Support installing templates automatically from `export_presets…

### DIFF
--- a/Fgvm.Cli/Command/LocalCommand.cs
+++ b/Fgvm.Cli/Command/LocalCommand.cs
@@ -1,38 +1,106 @@
 using ConsoleAppFramework;
 using Fgvm.Cli.Error;
 using Fgvm.Cli.Services;
+using Fgvm.Error;
+using Fgvm.Godot;
+using Fgvm.Types;
 using Microsoft.Extensions.Logging;
 using Spectre.Console;
 
 
 namespace Fgvm.Cli.Command;
 
-public sealed class LocalCommand(IVersionManagementService versionManagementService, IAnsiConsole console, ILogger<LocalCommand> logger)
+public sealed class LocalCommand(
+    IVersionManagementService versionManagementService,
+    IExportPresetCatalog exportPresetCatalog,
+    ITemplateOrchestrator templateOrchestrator,
+    IAnsiConsole console,
+    ILogger<LocalCommand> logger
+)
 {
     /// <summary>
-    ///     Set the Godot version for the current project.
+    ///     Prepare the Godot editor and export templates for the current project.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <param name="query">Version query arguments</param>
     /// <exception cref="ArgumentException">Thrown when a requested version query cannot be resolved during installation.</exception>
     /// <exception cref="InvalidOperationException">
-    ///     Thrown when project information, installed versions, installation state, or
+    ///     Thrown when project information, export presets, editor/template installation state, or
     ///     `.fgvm-version` writes cannot continue.
     /// </exception>
     /// <exception cref="OperationCanceledException">Thrown when interactive selection or installation is canceled.</exception>
     [Command("local")]
     public async Task Local(CancellationToken cancellationToken = default, [Argument] params string[] query)
     {
+        Release? godotRelease = null;
+        var templatesRequired = false;
+
         try
         {
-            var godotRelease =
+            var exportPresets = ReadExportPresets();
+            templatesRequired = exportPresets.Any(preset => preset.IsConfigured);
+            godotRelease =
                 await versionManagementService.SetLocalVersionAsync(query.Length > 0 ? query : null, cancellationToken: cancellationToken);
+
+            if (templatesRequired)
+            {
+                Result<TemplateInstallationOutcome, TemplateInstallationError> templateResult;
+                try
+                {
+                    templateResult = await templateOrchestrator.InstallAsync(
+                        [godotRelease.ReleaseNameWithRuntime],
+                        cancellationToken: cancellationToken);
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception exception)
+                {
+                    logger.LogError(exception,
+                        "Local version {Release} was set, but export template installation failed: {Message}",
+                        godotRelease.ReleaseNameWithRuntime,
+                        exception.Message);
+                    console.MarkupLine(Messages.LocalTemplateInstallationFailed(
+                        godotRelease.ReleaseNameWithRuntime,
+                        exception.Message));
+                    throw new ProcessExitCodeException(ExitCodes.GeneralError);
+                }
+
+                if (templateResult is Result<TemplateInstallationOutcome, TemplateInstallationError>.Failure(var error))
+                {
+                    var reason = TemplateInstallationResult.DescribeError(error);
+                    logger.LogError(
+                        "Local version {Release} was set, but export template installation failed: {Reason}",
+                        godotRelease.ReleaseNameWithRuntime,
+                        reason);
+                    console.MarkupLine(Messages.LocalTemplateInstallationFailed(godotRelease.ReleaseNameWithRuntime, reason));
+                    throw new ProcessExitCodeException(ExitCodes.GeneralError);
+                }
+            }
+
             console.MarkupLine(Messages.SetLocalVersion(godotRelease.ReleaseNameWithRuntime));
+        }
+        catch (OperationCanceledException) when (godotRelease is not null && templatesRequired)
+        {
+            logger.LogError(
+                "Local version {Release} was set, but export template installation was cancelled.",
+                godotRelease.ReleaseNameWithRuntime);
+            console.MarkupLine(Messages.LocalTemplateInstallationCancelled(godotRelease.ReleaseNameWithRuntime));
+            throw;
         }
         catch (OperationCanceledException)
         {
             logger.LogError("User cancelled setting local version.");
             console.MarkupLine(Messages.UserCancelled("setting local version"));
+            throw;
+        }
+        catch (ConfigurationException)
+        {
+            throw;
+        }
+        catch (ProcessExitCodeException)
+        {
             throw;
         }
         catch (ArgumentException)
@@ -46,4 +114,17 @@ public sealed class LocalCommand(IVersionManagementService versionManagementServ
             throw;
         }
     }
+
+    private IReadOnlyList<ExportPreset> ReadExportPresets() =>
+        exportPresetCatalog.Read() switch
+        {
+            Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Success(var presets) => presets,
+            Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure(
+                ExportPresetCatalogError.InvalidConfiguration(var path, var line, var message)) =>
+                throw new ConfigurationException($"Invalid export preset configuration in '{path}' at line {line}: {message}"),
+            Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure(
+                ExportPresetCatalogError.FileAccess(var error)) =>
+                throw new ConfigurationException($"Unable to read export presets: {error}"),
+            _ => throw new InvalidOperationException("Unexpected export preset catalog result type.")
+        };
 }

--- a/Fgvm.Cli/Command/TemplateCommand.cs
+++ b/Fgvm.Cli/Command/TemplateCommand.cs
@@ -1,4 +1,3 @@
-using System.Security;
 using System.Text.Json.Serialization;
 using ConsoleAppFramework;
 using Fgvm.Cli.Error;
@@ -37,22 +36,8 @@ public sealed class TemplateCommand(
     {
         try
         {
-            switch (await templateOrchestrator.InstallAsync(query, force, verbose, cancellationToken))
-            {
-                case Result<TemplateInstallationOutcome, TemplateInstallationError>.Success:
-                    return;
-                case Result<TemplateInstallationOutcome, TemplateInstallationError>.Failure(TemplateInstallationError.InvalidQuery invalid):
-                    throw new ArgumentException(invalid.Message);
-                case Result<TemplateInstallationOutcome, TemplateInstallationError>.Failure(TemplateInstallationError.NotFound notFound):
-                    throw new ArgumentException(Messages.TemplateInstallationNotFound(notFound.Version));
-                case Result<TemplateInstallationOutcome, TemplateInstallationError>.Failure(TemplateInstallationError.ChecksumMismatch
-                    mismatch):
-                    throw new SecurityException(Messages.ChecksumMismatch(mismatch.FileName, mismatch.Expected, mismatch.Actual));
-                case Result<TemplateInstallationOutcome, TemplateInstallationError>.Failure(TemplateInstallationError.Failed failed):
-                    throw new InvalidOperationException(Messages.TemplateInstallationFailed(failed.Reason));
-                default:
-                    throw new InvalidOperationException("Unknown template installation result type.");
-            }
+            TemplateInstallationResult.EnsureSuccess(
+                await templateOrchestrator.InstallAsync(query, force, verbose, cancellationToken));
         }
         catch (OperationCanceledException)
         {

--- a/Fgvm.Cli/Error/Messages.cs
+++ b/Fgvm.Cli/Error/Messages.cs
@@ -1,4 +1,5 @@
 using Fgvm.Environment;
+using Spectre.Console;
 
 namespace Fgvm.Cli.Error;
 
@@ -68,7 +69,7 @@ public static class Messages
 
     public static string CurrentVersionSetTo(string symlinkPath) => $"[green]Current version set to:[/] {symlinkPath}";
     public static string CurrentMacOSAppSetTo(string macAppSymlinkPath) => $"\n[green]Current macOS App set to:[/] {macAppSymlinkPath}";
-    public static string ConfigurationError(string message) => $"[red]Configuration error: {message}[/]";
+    public static string ConfigurationError(string message) => $"[red]Configuration error: {Markup.Escape(message)}[/]";
     public static string ExceptionMessage(string message)
     {
         var trimmed = message.Trim();
@@ -79,7 +80,8 @@ public static class Messages
         }
 
         var punctuation = punctuationProbe.EndsWith('.') || punctuationProbe.EndsWith('!') || punctuationProbe.EndsWith('?');
-        return punctuation ? $"[red]{trimmed}[/]" : $"[red]{trimmed}.[/]";
+        var escaped = Markup.Escape(trimmed);
+        return punctuation ? $"[red]{escaped}[/]" : $"[red]{escaped}.[/]";
     }
 
     public static string SelectAVersionTo(string what) => $"[green]Select a version to {what}[/]\n[hotpink_1](Press CTRL+C to cancel)[/]";
@@ -198,14 +200,18 @@ public static class Messages
     public static string NoTemplatesInstalled => "[yellow]No Godot export templates installed.[/]";
     public static string NoTemplatesToRemove => "[orange1] No export templates available to remove. [/]";
     public static string TemplateAlreadyInstalled(string templateVersion, string path) =>
-        $"[yellow]Export templates {templateVersion} are already installed at {path}[/]";
+        $"[yellow]Export templates {Markup.Escape(templateVersion)} are already installed at {Markup.Escape(path)}[/]";
     public static string TemplateInstallationSuccess(string templateVersion, string path) =>
-        $"[green]Finished installing export templates {templateVersion} to {path}![/]";
+        $"[green]Finished installing export templates {Markup.Escape(templateVersion)} to {Markup.Escape(path)}![/]";
     public static string TemplateChecksumUnavailable(string templateVersion) =>
-        $"[orange1]Warning: Checksum unavailable for export templates {templateVersion}. Installation continued without verification.[/]";
+        $"[orange1]Warning: Checksum unavailable for export templates {Markup.Escape(templateVersion)}. Installation continued without verification.[/]";
     public static string TemplateInstallationNotFound(string version) =>
         $"[red]Export templates for {version} could not be found.[/]";
     public static string TemplateInstallationFailed(string reason) => $"[red]Export template installation failed: {reason}[/]";
+    public static string LocalTemplateInstallationFailed(string releaseNameWithRuntime, string reason) =>
+        $"[red]Set local version to {Markup.Escape(releaseNameWithRuntime)}, but export template installation failed: {Markup.Escape(reason)}[/]";
+    public static string LocalTemplateInstallationCancelled(string releaseNameWithRuntime) =>
+        $"[orange1]Set local version to {Markup.Escape(releaseNameWithRuntime)}, but export template installation was cancelled.[/]";
     public static string OptionalTemplateInstallationFailed(string releaseNameWithRuntime, string reason) =>
         $"[orange1]Godot {releaseNameWithRuntime} is installed, but export template installation failed: {reason}[/]";
     public static string OptionalTemplateInstallationCancelled(string releaseNameWithRuntime) =>

--- a/Fgvm.Cli/Filter/ExitCodeFilter.cs
+++ b/Fgvm.Cli/Filter/ExitCodeFilter.cs
@@ -24,8 +24,8 @@ internal sealed class ExitCodeFilter(ConsoleAppFilter next) : ConsoleAppFilter(n
         }
         catch (ConfigurationException ex)
         {
-            AnsiConsole.MarkupLine(Messages.ConfigurationError(ex.Message));
             exitCode = ExitCodes.ConfigurationError;
+            Report(Messages.ConfigurationError(ex.Message));
         }
         catch (ProcessExitCodeException ex)
         {
@@ -36,8 +36,8 @@ internal sealed class ExitCodeFilter(ConsoleAppFilter next) : ConsoleAppFilter(n
                                       or ArgumentException
                                       or ArgumentParseFailedException)
         {
-            AnsiConsole.MarkupLine(Messages.ExceptionMessage(string.IsNullOrWhiteSpace(e.Message) ? "Invalid arguments" : e.Message));
             exitCode = ExitCodes.ArgumentError;
+            Report(Messages.ExceptionMessage(string.IsNullOrWhiteSpace(e.Message) ? "Invalid arguments" : e.Message));
         }
         catch (Exception)
         {
@@ -46,6 +46,29 @@ internal sealed class ExitCodeFilter(ConsoleAppFilter next) : ConsoleAppFilter(n
         finally
         {
             System.Environment.Exit(exitCode);
+        }
+    }
+
+    /// <summary>
+    ///     Renders a failure without wrapping so a path or query stays on one line and remains
+    ///     greppable. Callers assign the exit code first, so a rendering fault can only degrade the
+    ///     message, never turn the failure into a success.
+    /// </summary>
+    private static void Report(string markup)
+    {
+        var width = AnsiConsole.Profile.Width;
+        try
+        {
+            AnsiConsole.Profile.Width = int.MaxValue;
+            AnsiConsole.MarkupLine(markup);
+        }
+        catch (Exception)
+        {
+            Console.Error.WriteLine(markup);
+        }
+        finally
+        {
+            AnsiConsole.Profile.Width = width;
         }
     }
 }

--- a/Fgvm.Cli/Program.cs
+++ b/Fgvm.Cli/Program.cs
@@ -92,6 +92,7 @@ public class Program
         services.AddSingleton<IInstallationService, InstallationService>();
         services.AddSingleton<ITemplateInstallationService, TemplateInstallationService>();
         services.AddSingleton<IProjectManager, ProjectManager>();
+        services.AddSingleton<IExportPresetCatalog, ExportPresetCatalog>();
         services.AddSingleton<IInstallationOrchestrator, InstallationOrchestrator>();
         services.AddSingleton<ITemplateOrchestrator, TemplateOrchestrator>();
         services.AddSingleton(TimeProvider.System);

--- a/Fgvm.Cli/Services/TemplateInstallationResult.cs
+++ b/Fgvm.Cli/Services/TemplateInstallationResult.cs
@@ -1,0 +1,42 @@
+using System.Security;
+using Fgvm.Cli.Error;
+using Fgvm.Types;
+
+namespace Fgvm.Cli.Services;
+
+internal static class TemplateInstallationResult
+{
+    public static string DescribeError(TemplateInstallationError error) =>
+        error switch
+        {
+            TemplateInstallationError.InvalidQuery invalid => invalid.Message,
+            TemplateInstallationError.NotFound notFound => $"Export templates for {notFound.Version} could not be found.",
+            TemplateInstallationError.ChecksumMismatch mismatch =>
+                $"Checksum mismatch for {mismatch.FileName}: expected {mismatch.Expected}, got {mismatch.Actual}.",
+            TemplateInstallationError.Failed failed => failed.Reason,
+            _ => "Unknown template installation error."
+        };
+
+    public static void EnsureSuccess(Result<TemplateInstallationOutcome, TemplateInstallationError> result)
+    {
+        switch (result)
+        {
+            case Result<TemplateInstallationOutcome, TemplateInstallationError>.Success:
+                return;
+            case Result<TemplateInstallationOutcome, TemplateInstallationError>.Failure(
+                TemplateInstallationError.InvalidQuery invalid):
+                throw new ArgumentException(invalid.Message);
+            case Result<TemplateInstallationOutcome, TemplateInstallationError>.Failure(
+                TemplateInstallationError.NotFound notFound):
+                throw new ArgumentException(Messages.TemplateInstallationNotFound(notFound.Version));
+            case Result<TemplateInstallationOutcome, TemplateInstallationError>.Failure(
+                TemplateInstallationError.ChecksumMismatch mismatch):
+                throw new SecurityException(Messages.ChecksumMismatch(mismatch.FileName, mismatch.Expected, mismatch.Actual));
+            case Result<TemplateInstallationOutcome, TemplateInstallationError>.Failure(
+                TemplateInstallationError.Failed failed):
+                throw new InvalidOperationException(Messages.TemplateInstallationFailed(failed.Reason));
+            default:
+                throw new InvalidOperationException("Unknown template installation result type.");
+        }
+    }
+}

--- a/Fgvm.Cli/Services/VersionManagementService.cs
+++ b/Fgvm.Cli/Services/VersionManagementService.cs
@@ -293,12 +293,7 @@ public class VersionManagementService(
                 return CreateQuietVersionResolution(exactInstalledMatch, false);
             }
 
-            var installedReleaseNames = installed
-                .Select(version => releaseManager.CreateRelease(version))
-                .OfType<Result<Release, ReleaseParseError>.Success>()
-                .Select(success => success.Value.ReleaseName)
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
+            var installedReleaseNames = GetInstalledReleaseNames(installed);
             return releaseManager.ResolveReleaseQuery(query, installedReleaseNames) switch
             {
                 Result<Release, QueryError>.Success(var release) when installed.Contains(
@@ -927,11 +922,13 @@ public class VersionManagementService(
 
     private async Task<string> HandleQueryModeAsync(string[] query, string[] installed, CancellationToken cancellationToken)
     {
-        // Use query to find version - try to find exact match first
-        switch (releaseManager.ResolveReleaseQuery(query, installed))
+        // Installed registry entries include runtime suffixes, while release queries resolve from runtime-neutral release names.
+        var installedReleaseNames = GetInstalledReleaseNames(installed);
+        switch (releaseManager.ResolveReleaseQuery(query, installedReleaseNames))
         {
-            case Result<Release, QueryError>.Success(var release):
+            case Result<Release, QueryError>.Success(var release) when IsInstalled(release, installed):
                 return release.ReleaseNameWithRuntime;
+            case Result<Release, QueryError>.Success:
             case Result<Release, QueryError>.Failure(QueryError.NotFound):
                 break;
             case Result<Release, QueryError>.Failure(var error):
@@ -972,11 +969,14 @@ public class VersionManagementService(
                 throw new InvalidOperationException("Unexpected Result type");
         }
 
-        // Re-check installed versions after installation
+        // Re-check installed versions after installation.
         var updatedInstalled = ListInstallations().ToArray();
-        var foundVersion = releaseManager.ResolveReleaseQuery(query, updatedInstalled) switch
+        var updatedReleaseNames = GetInstalledReleaseNames(updatedInstalled);
+        var foundVersion = releaseManager.ResolveReleaseQuery(query, updatedReleaseNames) switch
         {
-            Result<Release, QueryError>.Success(var release) => release.ReleaseNameWithRuntime,
+            Result<Release, QueryError>.Success(var release) when IsInstalled(release, updatedInstalled) =>
+                release.ReleaseNameWithRuntime,
+            Result<Release, QueryError>.Success => null,
             Result<Release, QueryError>.Failure(QueryError.NotFound) => null,
             Result<Release, QueryError>.Failure(var error) => throw new ArgumentException(GetQueryErrorMessage(error, query)),
             _ => throw new InvalidOperationException("Unexpected Result type")
@@ -998,6 +998,24 @@ public class VersionManagementService(
         console.MarkupLine(Messages.SuccessfullyInstalled(releaseNameWithRuntime));
         return foundVersion;
     }
+
+    private static string[] GetInstalledReleaseNames(IEnumerable<string> installedVersions) =>
+        installedVersions
+            .Select(RemoveRuntimeSuffix)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    private static string RemoveRuntimeSuffix(string releaseNameWithRuntime) => releaseNameWithRuntime switch
+    {
+        _ when releaseNameWithRuntime.EndsWith("-mono", StringComparison.OrdinalIgnoreCase) => releaseNameWithRuntime[..^5],
+        _ when releaseNameWithRuntime.EndsWith("-standard", StringComparison.OrdinalIgnoreCase) => releaseNameWithRuntime[..^9],
+        _ => releaseNameWithRuntime
+    };
+
+    private static bool IsInstalled(Release release, IEnumerable<string> installedVersions) =>
+        installedVersions.Contains(release.ReleaseNameWithRuntime, StringComparer.OrdinalIgnoreCase) ||
+        release.RuntimeEnvironment == RuntimeEnvironment.Standard &&
+        installedVersions.Contains(release.ReleaseName, StringComparer.OrdinalIgnoreCase);
 
     private static string GetQueryErrorMessage(QueryError error, string[] query) => error switch
     {

--- a/Fgvm.Tests.Integration/CliIntegrationTests.cs
+++ b/Fgvm.Tests.Integration/CliIntegrationTests.cs
@@ -170,6 +170,32 @@ public class CliIntegrationTests(TestFixture fixture) : IClassFixture<TestFixtur
     }
 
     [Fact]
+    public async Task LocalRejectsMalformedExportPresetsBeforeChangingProjectState()
+    {
+        var project = NewTempPath("fgvm-local-[invalid]-presets");
+
+        try
+        {
+            await fixture.WriteFile(Path.Combine(project, "export_presets.cfg"),
+                "[preset.0]\nname=\"Web\"\nrunnable=perhaps\n");
+
+            var result = await fixture.ExecuteCommandInDirectory(["local", StableRelease], project);
+
+            Assert.Equal(ExitCodes.ConfigurationError, result.ExitCode);
+            Assert.Contains("Configuration error", result.Stdout);
+            Assert.Contains("export_presets.cfg", result.Stdout);
+            Assert.Contains("line 3", result.Stdout);
+            Assert.Contains("runnable", result.Stdout);
+            Assert.DoesNotContain("Something went wrong", result.Stdout);
+            Assert.False(await fixture.FileExists(Path.Combine(project, ".fgvm-version")));
+        }
+        finally
+        {
+            await fixture.DeletePath(project);
+        }
+    }
+
+    [Fact]
     public async Task InvalidVersionFailuresUseExpectedExitCodes()
     {
         var install = await fixture.ExecuteCommand(["install", "nonexistent-version-999"]);

--- a/Fgvm.Tests.Integration/TestFixture.cs
+++ b/Fgvm.Tests.Integration/TestFixture.cs
@@ -67,6 +67,9 @@ public sealed class TestFixture : IAsyncLifetime
     public async Task<CommandResult> ExecuteCommand(string[] args) =>
         await ExecuteProcess(FgvmPath, args, null, null);
 
+    public async Task<CommandResult> ExecuteCommandInDirectory(string[] args, string workingDirectory) =>
+        await ExecuteProcess(FgvmPath, args, workingDirectory, null);
+
     public async Task<CommandResult> ExecuteCommandWithEnvironment(string[] args, IReadOnlyDictionary<string, string> environment) =>
         await ExecuteProcess(FgvmPath, args, null, environment);
 

--- a/Fgvm.Tests/Command/LocalCommandTests.cs
+++ b/Fgvm.Tests/Command/LocalCommandTests.cs
@@ -1,0 +1,251 @@
+using Fgvm.Cli.Command;
+using Fgvm.Cli.Error;
+using Fgvm.Cli.Services;
+using Fgvm.Environment;
+using Fgvm.Error;
+using Fgvm.Godot;
+using Fgvm.Types;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Spectre.Console.Testing;
+
+namespace Fgvm.Tests.Command;
+
+public sealed class LocalCommandTests
+{
+    private readonly Mock<IExportPresetCatalog> _exportPresetCatalog = new();
+    private readonly Mock<ITemplateOrchestrator> _templateOrchestrator = new();
+    private readonly Mock<IVersionManagementService> _versionManagementService = new();
+
+    public static TheoryData<TemplateInstallationError, string> TemplateFailures =>
+        new()
+        {
+            { new TemplateInstallationError.InvalidQuery("invalid [query]"), "invalid [query]" },
+            { new TemplateInstallationError.NotFound("4.6.2-stable-standard"), "could not be found" },
+            {
+                new TemplateInstallationError.ChecksumMismatch("expected", "actual", "templates [fixture].tpz"),
+                "Checksum mismatch for templates [fixture].tpz"
+            },
+            { new TemplateInstallationError.Failed("download [unavailable]"), "download [unavailable]" }
+        };
+
+    [Fact]
+    public async Task Local_WithConfiguredPreset_InstallsTemplatesForSelectedRelease()
+    {
+        var release = CreateRelease("4.6.2-stable-standard");
+        SetupPresets([
+            new ExportPreset(0, "Web", "Web", "build/web/index.html", false)
+        ]);
+        SetupLocalRelease(release);
+        SetupTemplateSuccess("4.6.2.stable");
+        var command = CreateCommand(out var console);
+
+        await command.Local();
+
+        _templateOrchestrator.Verify(orchestrator => orchestrator.InstallAsync(
+            It.Is<string[]>(query => query.SequenceEqual(new[] { release.ReleaseNameWithRuntime })),
+            false,
+            false,
+            It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains("local version", console.Output, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Local_WithNoPresetFile_SkipsTemplateInstallation()
+    {
+        var release = CreateRelease("4.6.2-stable-standard");
+        SetupPresets([]);
+        SetupLocalRelease(release);
+        var command = CreateCommand(out _);
+
+        await command.Local();
+
+        _templateOrchestrator.Verify(orchestrator => orchestrator.InstallAsync(
+            It.IsAny<string[]>(),
+            It.IsAny<bool>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Local_WithOnlyIncompletePresets_SkipsTemplateInstallation()
+    {
+        var release = CreateRelease("4.6.2-stable-standard");
+        SetupPresets([
+            new ExportPreset(0, "Web", "Web", "", true)
+        ]);
+        SetupLocalRelease(release);
+        var command = CreateCommand(out _);
+
+        await command.Local();
+
+        _templateOrchestrator.Verify(orchestrator => orchestrator.InstallAsync(
+            It.IsAny<string[]>(),
+            It.IsAny<bool>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Local_WhenPresetCatalogFails_DoesNotChangeLocalVersion()
+    {
+        _exportPresetCatalog.Setup(catalog => catalog.Read(null))
+            .Returns(new Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure(
+                new ExportPresetCatalogError.InvalidConfiguration("/project/export_presets.cfg", 7, "Invalid runnable value.")));
+        var command = CreateCommand(out _);
+
+        var exception = await Assert.ThrowsAsync<ConfigurationException>(() => command.Local());
+
+        Assert.Contains("export_presets.cfg", exception.Message);
+        Assert.Contains("line 7", exception.Message);
+        _versionManagementService.Verify(service => service.SetLocalVersionAsync(
+            It.IsAny<string[]?>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Theory]
+    [MemberData(nameof(TemplateFailures))]
+    public async Task Local_WhenTemplateInstallationFails_ReportsReasonAfterSettingVersion(TemplateInstallationError templateError,
+        string expectedReason
+    )
+    {
+        var release = CreateRelease("4.6.2-stable-standard");
+        SetupPresets([
+            new ExportPreset(0, "Linux", "Linux/X11", "build/linux/game.x86_64", true)
+        ]);
+        SetupLocalRelease(release);
+        _templateOrchestrator.Setup(orchestrator => orchestrator.InstallAsync(
+                It.IsAny<string[]>(),
+                false,
+                false,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<TemplateInstallationOutcome, TemplateInstallationError>.Failure(templateError));
+        var command = CreateCommand(out var console);
+
+        var exception = await Assert.ThrowsAsync<ProcessExitCodeException>(() => command.Local());
+
+        Assert.Equal(ExitCodes.GeneralError, exception.ExitCode);
+        Assert.Contains("Set local version to 4.6.2-stable-standard", console.Output);
+        Assert.Contains(expectedReason, console.Output);
+        Assert.DoesNotContain("Something went wrong", console.Output);
+        _versionManagementService.Verify(service => service.SetLocalVersionAsync(
+            null,
+            false,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Local_WhenTemplateOrchestratorThrows_ReportsRetainedLocalVersionAndCause()
+    {
+        var release = CreateRelease("4.6.2-stable-standard");
+        SetupPresets([
+            new ExportPreset(0, "Web", "Web", "build/web/index.html", true)
+        ]);
+        SetupLocalRelease(release);
+        _templateOrchestrator.Setup(orchestrator => orchestrator.InstallAsync(
+                It.IsAny<string[]>(),
+                false,
+                false,
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new IOException("disk [full]"));
+        var command = CreateCommand(out var console);
+
+        var exception = await Assert.ThrowsAsync<ProcessExitCodeException>(() => command.Local());
+
+        Assert.Equal(ExitCodes.GeneralError, exception.ExitCode);
+        Assert.Contains("Set local version to 4.6.2-stable-standard", console.Output);
+        Assert.Contains("disk [full]", console.Output);
+        Assert.DoesNotContain("Something went wrong", console.Output);
+        _versionManagementService.Verify(service => service.SetLocalVersionAsync(
+            null,
+            false,
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Local_WhenPresetFileCannotBeRead_DoesNotChangeLocalVersion()
+    {
+        var fileError = new FileOperationError.PermissionDenied("/project/export_presets.cfg");
+        _exportPresetCatalog.Setup(catalog => catalog.Read(null))
+            .Returns(new Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure(
+                new ExportPresetCatalogError.FileAccess(fileError)));
+        var command = CreateCommand(out _);
+
+        var exception = await Assert.ThrowsAsync<ConfigurationException>(() => command.Local());
+
+        Assert.Contains("Permission denied", exception.Message);
+        Assert.Contains("export_presets.cfg", exception.Message);
+        _versionManagementService.Verify(service => service.SetLocalVersionAsync(
+            It.IsAny<string[]?>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _templateOrchestrator.Verify(orchestrator => orchestrator.InstallAsync(
+            It.IsAny<string[]>(),
+            It.IsAny<bool>(),
+            It.IsAny<bool>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Local_WhenTemplateInstallationIsCancelled_ReportsRetainedLocalVersion()
+    {
+        var release = CreateRelease("4.6.2-stable-standard");
+        SetupPresets([
+            new ExportPreset(0, "Web", "Web", "build/web/index.html", true)
+        ]);
+        SetupLocalRelease(release);
+        _templateOrchestrator.Setup(orchestrator => orchestrator.InstallAsync(
+                It.IsAny<string[]>(),
+                false,
+                false,
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+        var command = CreateCommand(out var console);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => command.Local());
+
+        Assert.Contains("Set local version to 4.6.2-stable-standard", console.Output);
+        Assert.Contains("was cancelled", console.Output);
+        Assert.DoesNotContain("User cancelled setting local version", console.Output);
+    }
+
+    private LocalCommand CreateCommand(out TestConsole console)
+    {
+        console = new TestConsole();
+        console.Profile.Width = 200;
+        return new LocalCommand(
+            _versionManagementService.Object,
+            _exportPresetCatalog.Object,
+            _templateOrchestrator.Object,
+            console,
+            NullLogger<LocalCommand>.Instance);
+    }
+
+    private void SetupPresets(IReadOnlyList<ExportPreset> presets) =>
+        _exportPresetCatalog.Setup(catalog => catalog.Read(null))
+            .Returns(new Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Success(presets));
+
+    private void SetupLocalRelease(Release release) =>
+        _versionManagementService.Setup(service => service.SetLocalVersionAsync(
+                null,
+                false,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(release);
+
+    private void SetupTemplateSuccess(string templateVersion) =>
+        _templateOrchestrator.Setup(orchestrator => orchestrator.InstallAsync(
+                It.IsAny<string[]>(),
+                false,
+                false,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Result<TemplateInstallationOutcome, TemplateInstallationError>.Success(
+                new TemplateInstallationOutcome.AlreadyInstalled(templateVersion, $"/templates/{templateVersion}")));
+
+    private static Release CreateRelease(string releaseNameWithRuntime)
+    {
+        var release = Release.TryParse(releaseNameWithRuntime);
+        Assert.NotNull(release);
+        return release;
+    }
+}

--- a/Fgvm.Tests/Godot/ExportPresetCatalogTests.cs
+++ b/Fgvm.Tests/Godot/ExportPresetCatalogTests.cs
@@ -1,0 +1,483 @@
+using Fgvm.Environment;
+using Fgvm.Godot;
+using Fgvm.Types;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Fgvm.Tests.Godot;
+
+public sealed class ExportPresetCatalogTests : IDisposable
+{
+    private readonly ExportPresetCatalog _catalog;
+    private readonly string _tempDirectory;
+
+    public ExportPresetCatalogTests()
+    {
+        _tempDirectory = Path.Combine(Path.GetTempPath(), $"fgvm-export-presets-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDirectory);
+
+        var pathService = new Mock<IPathService>();
+        var hostSystem = new HostSystem(new SystemInfo(), pathService.Object, NullLogger<HostSystem>.Instance);
+        _catalog = new ExportPresetCatalog(hostSystem);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, true);
+        }
+    }
+
+    [Fact]
+    public void Read_WithCompletePresets_ReturnsAllPresetMetadataInIndexOrder()
+    {
+        WritePresets("""
+                     [preset.1]
+
+                     name="Web"
+                     platform="Web"
+                     runnable=false
+                     export_path="build/web/index.html"
+
+                     [preset.0]
+
+                     name="Linux/X11"
+                     platform="Linux/X11"
+                     runnable=true
+                     export_path="build/linux/game.x86_64"
+                     """);
+
+        var presets = ReadPresets();
+
+        Assert.Collection(
+            presets,
+            preset =>
+            {
+                Assert.Equal(0, preset.Index);
+                Assert.Equal("Linux/X11", preset.Name);
+                Assert.Equal("Linux/X11", preset.Platform);
+                Assert.True(preset.Runnable is true);
+                Assert.Equal("build/linux/game.x86_64", preset.ExportPath);
+                Assert.True(preset.IsConfigured);
+            },
+            preset =>
+            {
+                Assert.Equal(1, preset.Index);
+                Assert.Equal("Web", preset.Name);
+                Assert.Equal("Web", preset.Platform);
+                Assert.True(preset.Runnable is false);
+                Assert.Equal("build/web/index.html", preset.ExportPath);
+                Assert.True(preset.IsConfigured);
+            });
+    }
+
+    [Fact]
+    public void Read_WithoutPresetZero_ReturnsEmptyCatalog()
+    {
+        WritePresets("""
+                     [preset.1]
+                     name="Web"
+                     platform="Web"
+                     export_path="build/web/index.html"
+                     """);
+
+        var presets = ReadPresets();
+
+        Assert.Empty(presets);
+    }
+
+    [Fact]
+    public void Read_AfterIndexGap_IgnoresLaterPresets()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Linux"
+                     platform="Linux/BSD"
+                     export_path="build/linux/game.x86_64"
+
+                     [preset.2]
+                     name="Web"
+                     platform="Web"
+                     export_path="build/web/index.html"
+                     """);
+
+        var preset = Assert.Single(ReadPresets());
+
+        Assert.Equal(0, preset.Index);
+        Assert.Equal("Linux", preset.Name);
+    }
+
+    [Fact]
+    public void Read_WithNoExportPresetsFile_ReturnsEmptyCatalog()
+    {
+        var presets = ReadPresets();
+
+        Assert.Empty(presets);
+    }
+
+    [Fact]
+    public void Read_WithIncompletePreset_PreservesItWithoutMarkingItConfigured()
+    {
+        WritePresets("""
+                     [preset.0]
+
+                     name="Linux/X11"
+                     platform="Linux/X11"
+                     runnable=true
+                     export_path=""
+                     """);
+
+        var preset = Assert.Single(ReadPresets());
+
+        Assert.False(preset.IsConfigured);
+    }
+
+    [Fact]
+    public void Read_WithOmittedRunnable_PreservesMissingValue()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Web"
+                     platform="Web"
+                     export_path="build/web/index.html"
+                     """);
+
+        var preset = Assert.Single(ReadPresets());
+
+        Assert.Null(preset.Runnable);
+        Assert.True(preset.IsConfigured);
+    }
+
+    [Fact]
+    public void Read_IgnoresPresetOptionsAndUnrelatedSections()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Web"
+                     platform="Web"
+                     runnable=true
+                     export_path="build/web/index.html"
+                     advanced_options=false
+                     custom_features="dedicated_server"
+
+                     [preset.0.options]
+                     name="not the preset name"
+                     platform="Android"
+                     export_path="outside.zip"
+
+                     [application]
+                     name="also ignored"
+                     """);
+
+        var preset = Assert.Single(ReadPresets());
+
+        Assert.Equal("Web", preset.Name);
+        Assert.Equal("Web", preset.Platform);
+        Assert.Equal("build/web/index.html", preset.ExportPath);
+    }
+
+    [Fact]
+    public void Read_WithGodotComments_StripsSemicolonsOnlyOutsideStrings()
+    {
+        WritePresets("""
+                     ; file comment
+                     [preset.0] ; section comment
+                     name="Web; \"Release\"" ; field comment
+                     platform="Web" ; field comment
+                     runnable=false ; field comment
+                     export_path="build/web;beta/index.html" ; field comment
+                     """);
+
+        var preset = Assert.Single(ReadPresets());
+
+        Assert.Equal("Web; \"Release\"", preset.Name);
+        Assert.Equal("build/web;beta/index.html", preset.ExportPath);
+        Assert.False(preset.Runnable);
+    }
+
+    [Fact]
+    public void Read_WithHashPseudoComment_ReturnsLineAwareParseError()
+    {
+        WritePresets("""
+                     [preset.0]
+                     # not a Godot ConfigFile comment
+                     name="Web"
+                     platform="Web"
+                     export_path="build/web/index.html"
+                     """);
+
+        var result = _catalog.Read(_tempDirectory);
+
+        var failure = Assert.IsType<Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure>(result);
+        var error = Assert.IsType<ExportPresetCatalogError.InvalidConfiguration>(failure.Error);
+        Assert.Equal(2, error.Line);
+        Assert.Contains("key/value", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_DecodesQuotedEscapesInRelevantValues()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Windows \"Desktop\""
+                     platform="Windows Desktop"
+                     runnable=true
+                     export_path="build\\windows\\game.exe"
+                     """);
+
+        var preset = Assert.Single(ReadPresets());
+
+        Assert.Equal("Windows \"Desktop\"", preset.Name);
+        Assert.Equal("build\\windows\\game.exe", preset.ExportPath);
+    }
+
+    [Theory]
+    [InlineData("perhaps")]
+    [InlineData("TRUE")]
+    [InlineData("False")]
+    public void Read_WithInvalidRunnable_ReturnsLineAwareParseError(string value)
+    {
+        WritePresets($"""
+                      [preset.0]
+                      name="Web"
+                      platform="Web"
+                      runnable={value}
+                      export_path="build/web/index.html"
+                      """);
+
+        var result = _catalog.Read(_tempDirectory);
+
+        var failure = Assert.IsType<Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure>(result);
+        var error = Assert.IsType<ExportPresetCatalogError.InvalidConfiguration>(failure.Error);
+        Assert.Equal(4, error.Line);
+        Assert.Contains("runnable", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("name=Web", "quoted string")]
+    [InlineData("name=\"Web\\q\"", "unsupported escape")]
+    [InlineData("name=\"Web\" trailing", "after the closing quote")]
+    [InlineData("name=\"Web\\", "unterminated escape")]
+    [InlineData("name=\"Web", "missing closing quote")]
+    public void Read_WithMalformedRelevantString_ReturnsSpecificParseError(string assignment, string expectedMessage)
+    {
+        WritePresets($"[preset.0]\n{assignment}\n");
+
+        var result = _catalog.Read(_tempDirectory);
+
+        var failure = Assert.IsType<Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure>(result);
+        var error = Assert.IsType<ExportPresetCatalogError.InvalidConfiguration>(failure.Error);
+        Assert.Equal(2, error.Line);
+        Assert.Contains(expectedMessage, error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_WithDuplicateRelevantKey_ReturnsParseError()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Web"
+                     name="Duplicate"
+                     """);
+
+        var result = _catalog.Read(_tempDirectory);
+
+        var failure = Assert.IsType<Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure>(result);
+        var error = Assert.IsType<ExportPresetCatalogError.InvalidConfiguration>(failure.Error);
+        Assert.Equal(3, error.Line);
+        Assert.Contains("duplicate name", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_WhenPresetFileCannotBeRead_ReturnsFileAccessError()
+    {
+        var fileError = new FileOperationError.PermissionDenied("/project/export_presets.cfg");
+        var hostSystem = new Mock<IHostSystem>();
+        hostSystem.Setup(system => system.ReadAllText(It.IsAny<string>()))
+            .Returns(new Result<string, FileOperationError>.Failure(fileError));
+        var catalog = new ExportPresetCatalog(hostSystem.Object);
+
+        var result = catalog.Read("/project");
+
+        var failure = Assert.IsType<Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure>(result);
+        var error = Assert.IsType<ExportPresetCatalogError.FileAccess>(failure.Error);
+        Assert.Equal(fileError, error.Error);
+    }
+
+    [Fact]
+    public void Read_WhenFileReadFails_ReturnsFileAccessError()
+    {
+        var fileError = new FileOperationError.IoFailure("/project/export_presets.cfg");
+        var hostSystem = new Mock<IHostSystem>();
+        hostSystem.Setup(system => system.ReadAllText(It.IsAny<string>()))
+            .Returns(new Result<string, FileOperationError>.Failure(fileError));
+        var catalog = new ExportPresetCatalog(hostSystem.Object);
+
+        var result = catalog.Read("/project");
+
+        var failure = Assert.IsType<Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure>(result);
+        var error = Assert.IsType<ExportPresetCatalogError.FileAccess>(failure.Error);
+        Assert.Equal(fileError, error.Error);
+    }
+
+    [Fact]
+    public void Read_WithDuplicatePresetIndex_ReturnsParseError()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Linux"
+
+                     [preset.0]
+                     name="Web"
+                     """);
+
+        var result = _catalog.Read(_tempDirectory);
+
+        var failure = Assert.IsType<Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure>(result);
+        var error = Assert.IsType<ExportPresetCatalogError.InvalidConfiguration>(failure.Error);
+        Assert.Equal(4, error.Line);
+        Assert.Contains("duplicate", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Read_WithMultilineOptionScript_IgnoresItsBodyEntirely()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Windows Desktop"
+                     platform="Windows Desktop"
+                     runnable=true
+                     export_path="build/windows/game.exe"
+
+                     [preset.0.options]
+                     ssh_remote_deploy/run_script="Param($a)
+                     [System.IO.File]::WriteAllText($a, 'x')
+                     $trigger = New-ScheduledTaskTrigger -Once -At 00:00
+                     Start-ScheduledTask -TaskName godot_remote_debug"
+                     binary_format/architecture="x86_64"
+                     """);
+
+        var preset = Assert.Single(ReadPresets());
+
+        Assert.Equal("Windows Desktop", preset.Name);
+        Assert.Equal("build/windows/game.exe", preset.ExportPath);
+    }
+
+    [Fact]
+    public void Read_WithPresetHeaderInsideMultilineString_DoesNotCreateAPhantomPreset()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Linux"
+                     platform="Linux"
+                     export_path="build/linux/game"
+
+                     [preset.0.options]
+                     ssh_remote_deploy/cleanup_script="echo start
+                     [preset.1]
+                     echo done"
+                     """);
+
+        var preset = Assert.Single(ReadPresets());
+
+        Assert.Equal("Linux", preset.Name);
+    }
+
+    [Fact]
+    public void Read_WithDuplicatePresetHeaderInsideMultilineString_DoesNotReportADuplicateIndex()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Linux"
+                     platform="Linux"
+                     export_path="build/linux/game"
+
+                     [preset.0.options]
+                     ssh_remote_deploy/run_script="echo start
+                     [preset.0]
+                     echo done"
+                     """);
+
+        var preset = Assert.Single(ReadPresets());
+
+        Assert.Equal("Linux", preset.Name);
+    }
+
+    [Fact]
+    public void Read_WithMultilineValueForUnconsumedKey_IgnoresIt()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Linux"
+                     platform="Linux"
+                     export_path="build/linux/game"
+                     custom_features="alpha
+                     beta"
+                     """);
+
+        var preset = Assert.Single(ReadPresets());
+
+        Assert.Equal("Linux", preset.Name);
+        Assert.Equal("build/linux/game", preset.ExportPath);
+    }
+
+    [Fact]
+    public void Read_WithUnterminatedValueOnIgnoredKey_DoesNotSilentlyDiscardLaterPresets()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Web"
+                     platform="Web"
+                     custom_features="oops
+                     export_path="build/web/index.html"
+
+                     [preset.1]
+                     name="Linux"
+                     platform="Linux"
+                     export_path="build/linux/game"
+                     """);
+
+        var result = _catalog.Read(_tempDirectory);
+
+        // Either outcome is defensible; silently returning one incomplete preset is not.
+        switch (result)
+        {
+            case Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure:
+                return;
+            case Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Success(var presets):
+                Assert.Equal(2, presets.Count);
+                return;
+        }
+    }
+
+    [Fact]
+    public void Read_WithMultilineConsumedValue_ReturnsLineAwareParseError()
+    {
+        WritePresets("""
+                     [preset.0]
+                     name="Web
+                     still the name"
+                     platform="Web"
+                     """);
+
+        var result = _catalog.Read(_tempDirectory);
+
+        var failure = Assert.IsType<Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure>(result);
+        var error = Assert.IsType<ExportPresetCatalogError.InvalidConfiguration>(failure.Error);
+        Assert.Equal(2, error.Line);
+        Assert.Contains("name", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private IReadOnlyList<ExportPreset> ReadPresets() =>
+        _catalog.Read(_tempDirectory) switch
+        {
+            Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Success(var presets) => presets,
+            Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure(var error) =>
+                throw new Xunit.Sdk.XunitException($"Expected export presets, got {error}"),
+            _ => throw new InvalidOperationException("Unexpected result type")
+        };
+
+    private void WritePresets(string content) =>
+        File.WriteAllText(Path.Combine(_tempDirectory, ExportPresetCatalog.FileName), content);
+}

--- a/Fgvm.Tests/Godot/ExportPresetTests.cs
+++ b/Fgvm.Tests/Godot/ExportPresetTests.cs
@@ -1,0 +1,21 @@
+using Fgvm.Types;
+
+namespace Fgvm.Tests.Godot;
+
+public sealed class ExportPresetTests
+{
+    [Theory]
+    [InlineData(null, "Web", "build/web/index.html")]
+    [InlineData("Web", null, "build/web/index.html")]
+    [InlineData("Web", "Web", null)]
+    [InlineData(" ", "\t", "\r\n")]
+    public void IsConfigured_RequiresNonWhitespaceNamePlatformAndExportPath(string? name,
+        string? platform,
+        string? exportPath
+    )
+    {
+        var preset = new ExportPreset(0, name, platform, exportPath, null);
+
+        Assert.False(preset.IsConfigured);
+    }
+}

--- a/Fgvm.Tests/Godot/ProjectManagerTests.cs
+++ b/Fgvm.Tests/Godot/ProjectManagerTests.cs
@@ -184,6 +184,50 @@ public sealed class ProjectManagerTests : IDisposable
     }
 
     [Fact]
+    public void FindProjectInfo_WithUnterminatedValue_FailsInsteadOfHidingTheDotNetSection()
+    {
+        var projectFilePath = Path.Combine(_tempDirectory, "project.godot");
+        const string projectContent = """
+                                      [application]
+                                      config/features=PackedStringArray("4.3", "C#")
+                                      config/description="oops
+                                      run/main_scene="res://main.tscn"
+
+                                      [dotnet]
+                                      project/assembly_name="TestProject"
+                                      """;
+
+        File.WriteAllText(projectFilePath, projectContent);
+
+        var result = _projectManager.FindProjectInfo(_tempDirectory);
+
+        var failure = Assert.IsType<Result<ProjectLookup<Release>, ProjectError>.Failure>(result);
+        Assert.IsType<ProjectError.InvalidProjectFile>(failure.Error);
+    }
+
+    [Fact]
+    public void FindProjectInfo_WithDotNetSectionInsideMultilineValue_RemainsStandard()
+    {
+        var projectFilePath = Path.Combine(_tempDirectory, "project.godot");
+        const string projectContent = """
+                                      [application]
+                                      config/name="Test Project"
+                                      config/features=PackedStringArray("4.3", "Forward Plus")
+                                      config/description="line one
+                                      [dotnet]
+                                      line three"
+                                      """;
+
+        File.WriteAllText(projectFilePath, projectContent);
+
+        var result = FindProjectInfoValue(_tempDirectory);
+
+        Assert.NotNull(result);
+        Assert.Equal("4.3-stable-standard", result.ReleaseNameWithRuntime);
+        Assert.False(result.IsDotNet);
+    }
+
+    [Fact]
     public void FindProjectInfo_WithProjectGodotStandardProject_ReturnsProjectInfoWithoutDotNet()
     {
         var projectFilePath = Path.Combine(_tempDirectory, "project.godot");

--- a/Fgvm.Tests/Services/VersionManagementServiceTests.cs
+++ b/Fgvm.Tests/Services/VersionManagementServiceTests.cs
@@ -455,6 +455,35 @@ public class VersionManagementServiceTests
     }
 
     [Fact]
+    public async Task SetLocalVersionAsync_WithBothRuntimes_HonorsExplicitStandardQuery()
+    {
+        var query = new[] { "4.6", "standard" };
+        const string standardVersion = "4.6.2-stable-standard";
+        var installedVersions = new[] { standardVersion, "4.6.2-stable-mono" };
+        var installedReleaseNames = new[] { "4.6.2-stable" };
+        var standardRelease = CreateMockRelease(standardVersion);
+
+        SetupInstallations(installedVersions);
+        SetupReleaseParsing(installedVersions);
+        _mockReleaseManager.Setup(x => x.ResolveReleaseQuery(
+                query,
+                It.Is<string[]>(versions => versions.SequenceEqual(installedReleaseNames))))
+            .Returns(standardRelease);
+
+        var result = await _service.SetLocalVersionAsync(query);
+
+        Assert.Equal(standardRelease, result);
+        _mockInstallationService.Verify(
+            x => x.InstallByQueryAsync(
+                It.IsAny<string[]>(),
+                It.IsAny<IProgress<OperationProgress<InstallationStage>>>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
     public async Task SetLocalVersionAsync_VersionNotInstalled_AttemptsInstallation()
     {
         const string queryVersion = "4.3.0";

--- a/Fgvm/Godot/ConfigScanner.cs
+++ b/Fgvm/Godot/ConfigScanner.cs
@@ -1,0 +1,185 @@
+namespace Fgvm.Godot;
+
+/// <summary>
+///     One meaningful line of a Godot ConfigFile document.
+/// </summary>
+internal abstract record ConfigEntry
+{
+    /// <summary>A section header such as <c>[preset.0.options]</c>.</summary>
+    internal sealed record Section(string Name, int Line) : ConfigEntry;
+
+    /// <summary>A complete single-line assignment; <c>Value</c> is raw, undecoded text.</summary>
+    internal sealed record Assignment(string? SectionName, string Key, string Value, int Line) : ConfigEntry;
+
+    /// <summary>
+    ///     An assignment whose value spans lines. Only the first physical line is retained, which is
+    ///     enough for callers to diagnose a key that must not span lines.
+    /// </summary>
+    internal sealed record Multiline(string? SectionName, string Key, string Value, int Line) : ConfigEntry;
+
+    /// <summary>A bracketed line that never closed.</summary>
+    internal sealed record MalformedSection(string? SectionName, int Line) : ConfigEntry;
+
+    /// <summary>A line that is neither a section header nor an assignment.</summary>
+    internal sealed record MalformedAssignment(string? SectionName, int Line) : ConfigEntry;
+
+    /// <summary>A value that opened a string or bracket and reached end of file still open.</summary>
+    internal sealed record UnterminatedValue(string? SectionName, string Key, string Value, int Line) : ConfigEntry;
+}
+
+/// <summary>
+///     Scans Godot ConfigFile documents (<c>project.godot</c>, <c>export_presets.cfg</c>) into a flat
+///     entry stream. It resolves structure only: quote and bracket state are tracked across line
+///     boundaries so a multiline Variant value can never be mistaken for a section or an assignment.
+///     Value decoding, key policy, and diagnostic wording belong to callers.
+/// </summary>
+/// <remarks>
+///     A value left open by a malformed document swallows the lines that follow it, exactly as
+///     Godot's own parser would. Callers must treat <see cref="ConfigEntry.UnterminatedValue" /> as
+///     a hard error, because everything it consumed is otherwise invisible. The residual case this
+///     cannot detect is a stray quote that happens to rebalance partway through the file: parsing
+///     resumes correctly, but the swallowed span is indistinguishable from legitimate string content.
+/// </remarks>
+internal ref struct ConfigScanner(ReadOnlySpan<char> content)
+{
+    private ReadOnlySpan<char> _remaining = content;
+    private string? _section;
+    private int _line;
+
+    // The foreach pattern requires public members even though the scanner itself is internal.
+    public ConfigEntry Current { get; private set; } = null!;
+
+    public readonly ConfigScanner GetEnumerator() => this;
+
+    public bool MoveNext()
+    {
+        while (!_remaining.IsEmpty)
+        {
+            var state = new ValueState();
+            var line = state.Consume(NextLine()).Trim();
+            if (line.IsEmpty)
+            {
+                continue;
+            }
+
+            var openedAt = _line;
+
+            if (line[0] == '[')
+            {
+                if (line is not ['[', .., ']'])
+                {
+                    Current = new ConfigEntry.MalformedSection(_section, openedAt);
+                    return true;
+                }
+
+                _section = line[1..^1].Trim().ToString();
+                Current = new ConfigEntry.Section(_section, openedAt);
+                return true;
+            }
+
+            var separator = line.IndexOf('=');
+            if (separator < 1)
+            {
+                Current = new ConfigEntry.MalformedAssignment(_section, openedAt);
+                return true;
+            }
+
+            var key = line[..separator].Trim().ToString();
+            var value = line[(separator + 1)..].Trim().ToString();
+
+            if (!state.IsOpen)
+            {
+                Current = new ConfigEntry.Assignment(_section, key, value, openedAt);
+                return true;
+            }
+
+            // The value opened a string or bracket that did not close on this line. Continuation
+            // lines are value body, never structure, so they are consumed verbatim.
+            while (state.IsOpen && !_remaining.IsEmpty)
+            {
+                state.Consume(NextLine());
+            }
+
+            Current = state.IsOpen
+                ? new ConfigEntry.UnterminatedValue(_section, key, value, openedAt)
+                : new ConfigEntry.Multiline(_section, key, value, openedAt);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     Takes the next physical line, splitting on <c>\n</c> exactly as Godot does and
+    ///     tolerating a trailing <c>\r</c>. Callers check <c>_remaining</c> first.
+    /// </summary>
+    private ReadOnlySpan<char> NextLine()
+    {
+        var index = _remaining.IndexOf('\n');
+        ReadOnlySpan<char> line;
+
+        if (index < 0)
+        {
+            line = _remaining;
+            _remaining = default;
+        }
+        else
+        {
+            line = _remaining[..index];
+            _remaining = _remaining[(index + 1)..];
+        }
+
+        _line++;
+        return line is [.., '\r'] ? line[..^1] : line;
+    }
+
+    /// <summary>
+    ///     Tracks whether a value is still open across physical lines.
+    /// </summary>
+    private struct ValueState
+    {
+        private int _depth;
+        private bool _escaped;
+        private bool _inString;
+
+        internal readonly bool IsOpen => _inString || _depth > 0;
+
+        /// <summary>
+        ///     Consumes one physical line and returns the text preceding any comment. A <c>;</c>
+        ///     begins a comment only outside a string, so separators inside values survive.
+        /// </summary>
+        internal ReadOnlySpan<char> Consume(ReadOnlySpan<char> line)
+        {
+            for (var index = 0; index < line.Length; index++)
+            {
+                if (_escaped)
+                {
+                    _escaped = false;
+                    continue;
+                }
+
+                switch (line[index])
+                {
+                    case '\\' when _inString:
+                        _escaped = true;
+                        break;
+                    case '"':
+                        _inString = !_inString;
+                        break;
+                    case '(' or '[' or '{' when !_inString:
+                        _depth++;
+                        break;
+                    case ')' or ']' or '}' when !_inString && _depth > 0:
+                        _depth--;
+                        break;
+                    case ';' when !_inString:
+                        return line[..index];
+                }
+            }
+
+            // A string stays open across lines; a dangling escape does not.
+            _escaped = false;
+            return line;
+        }
+    }
+}

--- a/Fgvm/Godot/ExportPresetCatalog.cs
+++ b/Fgvm/Godot/ExportPresetCatalog.cs
@@ -1,0 +1,354 @@
+using System.Globalization;
+using System.Text;
+using Fgvm.Environment;
+using Fgvm.Types;
+
+namespace Fgvm.Godot;
+
+public interface IExportPresetCatalog
+{
+    /// <summary>
+    ///     Reads the top-level export presets configured for a Godot project.
+    /// </summary>
+    /// <param name="projectDirectory">Project directory, or the current directory when omitted.</param>
+    Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError> Read(string? projectDirectory = null);
+}
+
+public abstract record ExportPresetCatalogError
+{
+    public sealed record FileAccess(FileOperationError Error) : ExportPresetCatalogError;
+
+    public sealed record InvalidConfiguration(string Path, int Line, string Message) : ExportPresetCatalogError;
+}
+
+/// <summary>
+///     Reads the small, stable subset of Godot's export preset configuration needed by fgvm.
+/// </summary>
+public sealed class ExportPresetCatalog(IHostSystem hostSystem) : IExportPresetCatalog
+{
+    public const string FileName = "export_presets.cfg";
+
+    /// <inheritdoc />
+    public Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError> Read(string? projectDirectory = null)
+    {
+        projectDirectory ??= Directory.GetCurrentDirectory();
+        var path = Path.Combine(projectDirectory, FileName);
+
+        return hostSystem.ReadAllText(path) switch
+        {
+            Result<string, FileOperationError>.Success(var content) => Parse(content, path),
+            Result<string, FileOperationError>.Failure(FileOperationError.NotFound) =>
+                new Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Success([]),
+            Result<string, FileOperationError>.Failure(var error) =>
+                new Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure(
+                    new ExportPresetCatalogError.FileAccess(error)),
+            _ => throw new InvalidOperationException("Unexpected result type")
+        };
+    }
+
+    internal static Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError> Parse(string content, string path)
+    {
+        var builders = new Dictionary<int, PresetBuilder>();
+        PresetBuilder? currentPreset = null;
+
+        foreach (var entry in new ConfigScanner(content))
+        {
+            switch (entry)
+            {
+                case ConfigEntry.MalformedSection(_, var line):
+                    return Failed(path, line, "Malformed section header.");
+
+                case ConfigEntry.Section(var name, var line):
+                    switch (SelectPreset(builders, name, path, line))
+                    {
+                        case Result<PresetBuilder?, ExportPresetCatalogError>.Failure(var sectionError):
+                            return Failed(sectionError);
+                        case Result<PresetBuilder?, ExportPresetCatalogError>.Success(var selected):
+                            currentPreset = selected;
+                            break;
+                    }
+
+                    break;
+
+                // Lines outside an active top-level preset are never fgvm's concern.
+                case ConfigEntry.MalformedAssignment when currentPreset is null:
+                    break;
+
+                case ConfigEntry.MalformedAssignment(_, var line):
+                    return Failed(path, line, "Expected an export preset key/value pair.");
+
+                case ConfigEntry.Assignment(_, var key, var value, var line) when currentPreset is not null:
+                    if (Apply(currentPreset, key, value, path, line) is
+                        Result<Unit, ExportPresetCatalogError>.Failure(var assignmentError))
+                    {
+                        return Failed(assignmentError);
+                    }
+
+                    break;
+
+                case ConfigEntry.Multiline(_, var key, var value, var line) when currentPreset is not null:
+                    if (RejectSpanningValue(key, value, path, line) is
+                        Result<Unit, ExportPresetCatalogError>.Failure(var multilineError))
+                    {
+                        return Failed(multilineError);
+                    }
+
+                    break;
+
+                // A value still open at end of file is malformed no matter whose key it is. Ignoring
+                // it would silently discard every line the runaway value swallowed.
+                case ConfigEntry.UnterminatedValue(_, var key, var value, var line):
+                    if (currentPreset is not null &&
+                        RejectSpanningValue(key, value, path, line) is
+                            Result<Unit, ExportPresetCatalogError>.Failure(var unterminatedError))
+                    {
+                        return Failed(unterminatedError);
+                    }
+
+                    return Failed(path, line, $"Unterminated value for '{key}'.");
+            }
+        }
+
+        var activePresets = new List<ExportPreset>();
+        for (var index = 0; builders.TryGetValue(index, out var builder); index++)
+        {
+            activePresets.Add(builder.Build());
+        }
+
+        return new Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Success(activePresets);
+    }
+
+    /// <summary>
+    ///     Activates the builder for a top-level <c>[preset.N]</c> section, and clears the active
+    ///     preset for anything else, including <c>[preset.N.options]</c>.
+    /// </summary>
+    private static Result<PresetBuilder?, ExportPresetCatalogError> SelectPreset(Dictionary<int, PresetBuilder> builders,
+        string section,
+        string path,
+        int line
+    )
+    {
+        if (!section.StartsWith("preset.", StringComparison.Ordinal))
+        {
+            return new Result<PresetBuilder?, ExportPresetCatalogError>.Success(null);
+        }
+
+        var presetSection = section["preset.".Length..];
+        var separator = presetSection.IndexOf('.');
+        var indexText = separator >= 0 ? presetSection[..separator] : presetSection;
+        if (!int.TryParse(indexText, NumberStyles.None, CultureInfo.InvariantCulture, out var index) || index < 0)
+        {
+            return new Result<PresetBuilder?, ExportPresetCatalogError>.Failure(
+                Invalid(path, line, $"Invalid export preset section '{section}'."));
+        }
+
+        if (separator >= 0)
+        {
+            return new Result<PresetBuilder?, ExportPresetCatalogError>.Success(null);
+        }
+
+        if (builders.ContainsKey(index))
+        {
+            return new Result<PresetBuilder?, ExportPresetCatalogError>.Failure(
+                Invalid(path, line, $"Duplicate export preset index {index}."));
+        }
+
+        var builder = new PresetBuilder(index);
+        builders.Add(index, builder);
+        return new Result<PresetBuilder?, ExportPresetCatalogError>.Success(builder);
+    }
+
+    private static Result<Unit, ExportPresetCatalogError> Apply(PresetBuilder preset,
+        string key,
+        string value,
+        string path,
+        int line
+    )
+    {
+        switch (key)
+        {
+            case "name":
+                return AssignString(preset, key, value, path, line, static (builder, decoded) => builder.Name = decoded);
+            case "platform":
+                return AssignString(preset, key, value, path, line, static (builder, decoded) => builder.Platform = decoded);
+            case "export_path":
+                return AssignString(preset, key, value, path, line, static (builder, decoded) => builder.ExportPath = decoded);
+            case "runnable":
+                if (value is not ("true" or "false"))
+                {
+                    return new Result<Unit, ExportPresetCatalogError>.Failure(
+                        Invalid(path, line, "Invalid runnable value; expected true or false."));
+                }
+
+                if (!preset.MarkAssigned(key))
+                {
+                    return new Result<Unit, ExportPresetCatalogError>.Failure(
+                        Invalid(path, line, $"Duplicate {key} value."));
+                }
+
+                preset.Runnable = value == "true";
+                return Unit.Value;
+            default:
+                // Ignore metadata fgvm does not consume.
+                return Unit.Value;
+        }
+    }
+
+    /// <summary>
+    ///     Decodes a quoted value and assigns it once. Decoding is validated before the duplicate
+    ///     check so a malformed repeat still reports why it is malformed.
+    /// </summary>
+    private static Result<Unit, ExportPresetCatalogError> AssignString(PresetBuilder preset,
+        string key,
+        string value,
+        string path,
+        int line,
+        Action<PresetBuilder, string> assign
+    )
+    {
+        if (!TryReadString(value, out var decoded, out var error))
+        {
+            return new Result<Unit, ExportPresetCatalogError>.Failure(
+                Invalid(path, line, $"Invalid {key} value: {error}"));
+        }
+
+        if (!preset.MarkAssigned(key))
+        {
+            return new Result<Unit, ExportPresetCatalogError>.Failure(
+                Invalid(path, line, $"Duplicate {key} value."));
+        }
+
+        assign(preset, decoded);
+        return Unit.Value;
+    }
+
+    /// <summary>
+    ///     Godot writes every value fgvm consumes on one line, so a value that spans lines is only
+    ///     an error when fgvm actually reads that key.
+    /// </summary>
+    private static Result<Unit, ExportPresetCatalogError> RejectSpanningValue(string key,
+        string value,
+        string path,
+        int line
+    )
+    {
+        switch (key)
+        {
+            case "name" or "platform" or "export_path":
+                // Diagnose from the retained first line without assigning anything: the value is
+                // being rejected, so the builder must not be mutated on the way out.
+                return new Result<Unit, ExportPresetCatalogError>.Failure(
+                    TryReadString(value, out _, out var error)
+                        ? Invalid(path, line, $"Invalid {key} value; it must not span lines.")
+                        : Invalid(path, line, $"Invalid {key} value: {error}"));
+            case "runnable":
+                return new Result<Unit, ExportPresetCatalogError>.Failure(
+                    Invalid(path, line, "Invalid runnable value; expected true or false."));
+            default:
+                return Unit.Value;
+        }
+    }
+
+    private static ExportPresetCatalogError.InvalidConfiguration Invalid(string path, int line, string message) =>
+        new(path, line, message);
+
+    private static Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError> Failed(ExportPresetCatalogError error) =>
+        new Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError>.Failure(error);
+
+    private static Result<IReadOnlyList<ExportPreset>, ExportPresetCatalogError> Failed(string path,
+        int line,
+        string message
+    ) =>
+        Failed(Invalid(path, line, message));
+
+    private static bool TryReadString(string value, out string result, out string error)
+    {
+        result = string.Empty;
+        error = string.Empty;
+        if (value.Length < 2 || value[0] != '"')
+        {
+            error = "expected a quoted string.";
+            return false;
+        }
+
+        var decoded = new StringBuilder(value.Length - 2);
+        var escaped = false;
+        for (var i = 1; i < value.Length; i++)
+        {
+            var character = value[i];
+            if (escaped)
+            {
+                switch (character)
+                {
+                    case '"':
+                    case '\\':
+                        decoded.Append(character);
+                        break;
+                    case 'n':
+                        decoded.Append('\n');
+                        break;
+                    case 'r':
+                        decoded.Append('\r');
+                        break;
+                    case 't':
+                        decoded.Append('\t');
+                        break;
+                    case 'b':
+                        decoded.Append('\b');
+                        break;
+                    case 'f':
+                        decoded.Append('\f');
+                        break;
+                    default:
+                        error = $"unsupported escape sequence \\{character}.";
+                        return false;
+                }
+
+                escaped = false;
+                continue;
+            }
+
+            if (character == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (character == '"')
+            {
+                if (i != value.Length - 1)
+                {
+                    error = "unexpected content after the closing quote.";
+                    return false;
+                }
+
+                result = decoded.ToString();
+                return true;
+            }
+
+            decoded.Append(character);
+        }
+
+        error = escaped ? "unterminated escape sequence." : "missing closing quote.";
+        return false;
+    }
+
+    private sealed class PresetBuilder(int index)
+    {
+        private readonly HashSet<string> _assigned = [];
+
+        public int Index { get; } = index;
+        public string? Name { get; set; }
+        public string? Platform { get; set; }
+        public string? ExportPath { get; set; }
+        public bool? Runnable { get; set; }
+
+        /// <summary>
+        ///     Records the first assignment of a consumed key and reports false for any repeat. A
+        ///     blank value is legitimate for <c>export_path</c>, so presence cannot stand in for this.
+        /// </summary>
+        public bool MarkAssigned(string key) => _assigned.Add(key);
+
+        public ExportPreset Build() => new(Index, Name, Platform, ExportPath, Runnable);
+    }
+}

--- a/Fgvm/Godot/ProjectManager.cs
+++ b/Fgvm/Godot/ProjectManager.cs
@@ -50,6 +50,8 @@ public partial class ProjectManager(IReleaseManager releaseManager, IHostSystem 
 {
     private const string VersionFile = ".fgvm-version";
     private const string ProjectFile = "project.godot";
+    private const string FeaturesKey = "config/features";
+    private const string DotNetSection = "dotnet";
 
     /// <inheritdoc />
     public Result<ProjectLookup<Release>, ProjectError> FindProjectInfo(string? directory = null) =>
@@ -213,29 +215,39 @@ public partial class ProjectManager(IReleaseManager releaseManager, IHostSystem 
                 throw new InvalidOperationException("Unexpected Result type");
         }
 
-        var lines = content.Split('\n', StringSplitOptions.RemoveEmptyEntries);
-
         string? version = null;
         var runtime = RuntimeEnvironment.Standard;
         var foundFeaturesLine = false;
         var malformedFeaturesLine = false;
 
-        foreach (var line in lines)
+        foreach (var entry in new ConfigScanner(content))
         {
-            var trimmedLine = line.Trim();
-
-            // Extract version from config/features
-            if (trimmedLine.StartsWith("config/features=PackedStringArray("))
+            switch (entry)
             {
-                foundFeaturesLine = true;
-                malformedFeaturesLine = trimmedLine.LastIndexOf(')') <= trimmedLine.IndexOf('(');
-                version = ExtractVersionFromFeatures(trimmedLine);
-            }
+                case ConfigEntry.Section(DotNetSection, _):
+                    runtime = RuntimeEnvironment.Mono;
+                    break;
 
-            // Check for .NET section
-            if (trimmedLine == "[dotnet]")
-            {
-                runtime = RuntimeEnvironment.Mono;
+                // A complete assignment has balanced brackets, so the array always closes.
+                case ConfigEntry.Assignment(_, FeaturesKey, var value, _) when IsFeaturesArray(value):
+                    foundFeaturesLine = true;
+                    malformedFeaturesLine = false;
+                    version = ExtractVersionFromFeatures(value);
+                    break;
+
+                // Godot never writes a features array across lines; one that spans is malformed.
+                case ConfigEntry.Multiline(_, FeaturesKey, var multiline, _) when IsFeaturesArray(multiline):
+                    foundFeaturesLine = true;
+                    malformedFeaturesLine = true;
+                    version = null;
+                    break;
+
+                // A value still open at end of file is malformed, and Godot cannot load the project
+                // either. Continuing would silently ignore everything the runaway value swallowed,
+                // including a [dotnet] section, and resolve a .NET project as standard.
+                case ConfigEntry.UnterminatedValue:
+                    return new Result<ProjectLookup<Release>, ProjectError>.Failure(
+                        new ProjectError.InvalidProjectFile(projectFilePath));
             }
         }
 
@@ -290,23 +302,26 @@ public partial class ProjectManager(IReleaseManager releaseManager, IHostSystem 
         _ => new ProjectError.WriteFailed(error.Path)
     };
 
+    private static bool IsFeaturesArray(string value) =>
+        value.StartsWith("PackedStringArray(", StringComparison.Ordinal);
+
     /// <summary>
-    ///     Extracts the Godot version from a config/features line.
+    ///     Extracts the Godot version from a config/features value.
     /// </summary>
-    /// <param name="featuresLine">The line containing config/features=PackedStringArray(...)</param>
+    /// <param name="featuresValue">The value of config/features, such as PackedStringArray(...)</param>
     /// <returns>The version string if found, null otherwise.</returns>
-    private static string? ExtractVersionFromFeatures(string featuresLine)
+    private static string? ExtractVersionFromFeatures(string featuresValue)
     {
-        // Example: config/features=PackedStringArray("4.4", "Forward Plus")
-        var startIndex = featuresLine.IndexOf('(');
-        var endIndex = featuresLine.LastIndexOf(')');
+        // Example: PackedStringArray("4.4", "Forward Plus")
+        var startIndex = featuresValue.IndexOf('(');
+        var endIndex = featuresValue.LastIndexOf(')');
 
         if (startIndex == -1 || endIndex == -1 || endIndex <= startIndex)
         {
             return null;
         }
 
-        var featuresContent = featuresLine.Substring(startIndex + 1, endIndex - startIndex - 1);
+        var featuresContent = featuresValue.Substring(startIndex + 1, endIndex - startIndex - 1);
 
         // Split by comma and look for version-like strings
         var features = featuresContent.Split(',')

--- a/Fgvm/Types/ExportPreset.cs
+++ b/Fgvm/Types/ExportPreset.cs
@@ -1,0 +1,21 @@
+namespace Fgvm.Types;
+
+/// <summary>
+///     A top-level export preset declared in a Godot project's <c>export_presets.cfg</c> file.
+/// </summary>
+public sealed record ExportPreset(
+    int Index,
+    string? Name,
+    string? Platform,
+    string? ExportPath,
+    bool? Runnable
+)
+{
+    /// <summary>
+    ///     Whether the preset contains the fields Godot needs to identify and write an export.
+    /// </summary>
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(Name) &&
+        !string.IsNullOrWhiteSpace(Platform) &&
+        !string.IsNullOrWhiteSpace(ExportPath);
+}

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ either by putting it somewhere on your `PATH` or, preferably, using a [package m
 - **Hybrid CLI/TUI Interface**: Simple command-line interface with interactive TUI prompts for easy navigation and selection when you don't specify arguments.
 - **Flexible Query System**: Powerful query system for finding and installing versions using keywords like `latest`, `4 mono`, `3.3 rc`, etc.
 - **Project Aware**: Lock a project to a specific Godot version using a `.fgvm-version` file in the project directory. `fgvm local` can automatically detect a compatible version from `project.godot`
-  or let you manually choose one, and will prompt to install missing versions when needed. `fgvm godot` uses `.fgvm-version` when present, otherwise falls back to the global default, and can launch the
-  current project directly from the terminal.
+  or let you manually choose one, will install missing versions when needed, and installs the matching full export-template package when `export_presets.cfg` contains a configured preset. `fgvm godot` uses
+  `.fgvm-version` when present, otherwise falls back to the global default, and can launch the current project directly from the terminal.
 - **Smart Argument Handling**: Detection of arguments passed to Godot that contextually switch to an attached mode when necessary to display terminal output.
 - **CI-Ready**: Suitable for remote installations, CI/CD pipelines, WSL, and containerized environments with its single self-contained native executable.
 
@@ -349,9 +349,13 @@ but here is a detailed summary of the available commands:
     - The command will only read existing `.fgvm-version` files for version selection, and does not create or modify version files. Use `fgvm local` to manage `.fgvm-version` files.
 - `fgvm set [<...strings>]` prompts the user to set an installed version of Godot if no arguments are supplied, or will
   try to find the closest matching version based on the query, including release type (`stable`) and version (`4`, `4.4`), or an exact match (`4.4.1-stable-mono`).
-- `fgvm local [<...strings>]` sets the Godot version for the current project by creating or updating a `.fgvm-version` file in the current directory. If no `.fgvm-version` file
+- `fgvm local [<...strings>]` prepares the Godot toolchain for the current project by creating or updating a `.fgvm-version` file in the current directory. If no `.fgvm-version` file
   exists and no arguments are provided, it will automatically detect the project version from `project.godot` and install the most recent compatible version if not already installed.
     - If a list of arguments are provided, it will find the best matching version based on the query (including runtime preferences like `mono` or `standard`) and install it if necessary.
+    - If `export_presets.cfg` contains at least one preset with a name, platform, and export path, it also installs the complete official export-template package matching the selected editor. Projects without
+      configured export presets retain the version-only behavior.
+    - fgvm validates the preset metadata it uses before the editor or `.fgvm-version` is changed. An unreadable file or malformed relevant field stops `local` with a configuration error containing the file and line when available; target-specific option values remain Godot's responsibility.
+    - If editor preparation succeeds but template installation fails or is cancelled, `local` exits non-zero and explicitly reports that the selected editor and `.fgvm-version` remain in place for a retry.
 - `fgvm which` `[<...strings>]` displays the executable path for the effective Godot installation in the current directory: `.fgvm-version` first, then the global default. If query arguments are supplied, it resolves them against installed versions instead. The command prints only the executable path on success and exits non-zero when no version can be resolved.
 - `fgvm remove` or `fgvm r` `[<...strings>]` [`--with-templates`] prompts the user to select multiple installations to delete, or optionally takes a query to filter down to specific versions to delete. If there is only one match, it
   will delete it directly. If there are multiple matches, it will prompt the user to select which ones to delete.
@@ -410,10 +414,10 @@ fgvm supports project-specific version management through `.fgvm-version` files.
 cd my-godot-project
 
 # Option 1: Auto-detect version from project.godot
-fgvm local                    # Detects version from project.godot, creates .fgvm-version
+fgvm local                    # Detects the version and prepares templates when export presets are configured
 
 # Option 2: Explicitly set a version
-fgvm local 4.3 mono          # Creates .fgvm-version with 4.3-stable-mono
+fgvm local 4.3 mono          # Creates .fgvm-version and prepares matching Mono templates when needed
 ```
 
 #### Using project versions:

--- a/e2e/tests/project.ps1
+++ b/e2e/tests/project.ps1
@@ -21,16 +21,81 @@ Suite "project versions" {
         Assert.Equal "4.5-stable-standard" (File.Read $versionPath).Trim()
     }
 
-    Test "selects a mono local version" {
+    Test "installs matching standard export templates when both runtimes are installed" {
+        Add-FixtureInstallation "4.6.2-stable" | Out-Null
+        Add-FixtureInstallation "4.6.2-stable" "mono" | Out-Null
+        $projectPath = Join-Path $Context.WorkPath "export-project"
+        New-Item -ItemType Directory -Path $projectPath -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $projectPath "export_presets.cfg") -Value @'
+[preset.0]
+name="Web"
+platform="Web"
+runnable=false
+export_path="build/web/index.html"
+'@ -NoNewline
+
+        $templatesRoot = Join-Path $Context.RootPath "godot-[export-templates"
+        $environment = @{ FGVM_GODOT_EXPORT_TEMPLATES_DIR = $templatesRoot }
+        $templatePayload = Join-Path $templatesRoot "4.6.2.stable" "mock-template.txt"
+
+        $local = Run -Cwd $projectPath -Environment $environment -Arguments @("local", "4.6", "standard")
+
+        Assert.ExitCode 0 $local "fgvm local 4.6 standard with export presets"
+        Assert.Contains "Finished installing export templates" $local.Stdout
+        Assert.Equal "4.6.2-stable-standard" (File.Read (Join-Path $projectPath ".fgvm-version")).Trim()
+        Assert.True (Test-Path -LiteralPath $templatePayload -PathType Leaf) "Local should install the full matching template package."
+        Assert.Equal "mock export template for 4.6.2-stable standard" (File.Read $templatePayload)
+    }
+
+    Test "retains the local version when export template installation fails" {
+        Add-FixtureInstallation "4.6.2-stable" | Out-Null
+        $projectPath = Join-Path $Context.WorkPath "failing-template-project"
+        New-Item -ItemType Directory -Path $projectPath -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $projectPath "export_presets.cfg") -Value @'
+[preset.0]
+name="Web"
+platform="Web"
+runnable=false
+export_path="build/web/index.html"
+'@ -NoNewline
+
+        $versionPath = Join-Path $projectPath ".fgvm-version"
+        $environment = @{
+            FGVM_GODOT_EXPORT_TEMPLATES_DIR    = Join-Path $Context.RootPath "failed-export-templates"
+            FGVM_INTEGRATION_FIXTURE_MANIFEST = Join-Path $Context.WorkPath "missing-fixture-manifest.json"
+        }
+
+        $local = Run -Cwd $projectPath -Environment $environment -Arguments @("local", "4.6")
+
+        Assert.ExitCode 1 $local "fgvm local 4.6 with unavailable export templates"
+        Assert.Contains "Set local version to 4.6.2-stable-standard" $local.Stdout
+        Assert.Contains "but export template installation" $local.Stdout
+        Assert.Contains "Release catalog hydration failed" $local.Stdout
+        Assert.NotContains "Finished installing export templates" $local.Stdout
+        Assert.Equal "4.6.2-stable-standard" (File.Read $versionPath).Trim()
+    }
+
+    Test "selects a mono local version and matching templates" {
         Add-FixtureInstallation "4.6.2-stable" | Out-Null
         Add-FixtureInstallation "4.6.2-stable" "mono" | Out-Null
         $projectPath = Join-Path $Context.WorkPath "mono-project"
         New-Item -ItemType Directory -Path $projectPath -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $projectPath "export_presets.cfg") -Value @'
+[preset.0]
+name="Linux"
+platform="Linux/X11"
+runnable=true
+export_path="build/linux/game.x86_64"
+'@ -NoNewline
+        $templatesRoot = Join-Path $Context.RootPath "godot-export-templates"
+        $environment = @{ FGVM_GODOT_EXPORT_TEMPLATES_DIR = $templatesRoot }
+        $templatePayload = Join-Path $templatesRoot "4.6.2.stable.mono" "mock-template.txt"
 
-        $local = Run -Cwd $projectPath "local" "4.6" "mono"
+        $local = Run -Cwd $projectPath -Environment $environment -Arguments @("local", "4.6", "mono")
 
         Assert.ExitCode 0 $local "fgvm local 4.6 mono"
         Assert.Equal "4.6.2-stable-mono" (File.Read (Join-Path $projectPath ".fgvm-version")).Trim()
+        Assert.Equal "mock export template for 4.6.2-stable mono" (File.Read $templatePayload)
     }
 
     Test "detects an installed version from project godot" {


### PR DESCRIPTION
….cfg` using `fgvm local`.

refactor: Implement a common ConfigFile scanner.